### PR TITLE
fix(README): update nodepool creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In order to setup the DOME-Marketplace, its recommended to install the following
 
 4. Create the initial nodepool inside your cluster and datacenter:
 ```shell
-    export DOME_K8S_DEFAULT_NODEPOOL_ID=$(ionosctl k8s nodepool create --cluster-id $DOME_K8S_CLUSTER_ID --name default-pool --node-count 2 --ram-size 8192 --storage-size 10 --datacenter-id $DOME_DATACENTER_ID --cpu-family "INTEL_SKYLAKE"  -o json | jq -r '.items[0].id')
+    export DOME_K8S_DEFAULT_NODEPOOL_ID=$(ionosctl k8s nodepool create --cluster-id $DOME_K8S_CLUSTER_ID --name default-pool --node-count 2 --ram 8192 --storage-size 10 --datacenter-id $DOME_DATACENTER_ID --cpu-family "INTEL_SKYLAKE"  -o json | jq -r '.items[0].id')
     # wait for the pool to be available
     watch ionosctl k8s nodepool get --nodepool-id $DOME_K8S_DEFAULT_NODEPOOL_ID --cluster-id $DOME_K8S_CLUSTER_ID
 ```


### PR DESCRIPTION
`--ram-size` option was renamed to `ram` in the latest version of the cli : https://docs.ionos.com/cli-ionosctl/subcommands/managed-kubernetes/nodepool/create