### PR TITLE
Add Zammad to Dev and Sbx environments

### DIFF
--- a/applications_dev/zammad.yaml
+++ b/applications_dev/zammad.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     path: ionos_dev/zammad
-    repoURL: https://github.com/ivanligot/dome-gitops
+    repoURL: https://github.com/DOME-Marketplace/dome-gitops
     targetRevision: HEAD
   syncPolicy:
     automated:

--- a/applications_dev/zammad.yaml
+++ b/applications_dev/zammad.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zammad
+  namespace: argocd
+  labels:
+    purpose: zammad
+spec:
+  destination:
+    namespace: zammad
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ionos_dev/zammad
+    repoURL: https://github.com/ivanligot/dome-gitops
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/applications_sbx/zammad.yaml
+++ b/applications_sbx/zammad.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zammad
+  namespace: argocd
+  labels:
+    purpose: zammad
+spec:
+  destination:
+    namespace: zammad
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ionos_sbx/zammad
+    repoURL: https://github.com/ivanligot/dome-gitops
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/applications_sbx/zammad.yaml
+++ b/applications_sbx/zammad.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     path: ionos_sbx/zammad
-    repoURL: https://github.com/ivanligot/dome-gitops
+    repoURL: https://github.com/DOME-Marketplace/dome-gitops
     targetRevision: HEAD
   syncPolicy:
     automated:

--- a/ionos_common/namespaces/zammad.yaml
+++ b/ionos_common/namespaces/zammad.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zammad

--- a/ionos_dev/namespaces/zammad.yaml
+++ b/ionos_dev/namespaces/zammad.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zammad

--- a/ionos_dev/zammad/Chart.yaml
+++ b/ionos_dev/zammad/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: zammad
+description: Chart holder for argo-cd
+
+type: application
+version: 12.0.0
+
+dependencies:
+- name: zammad
+  version: 12.0.0
+  repository: https://zammad.github.io/zammad-helm

--- a/ionos_dev/zammad/values.yaml
+++ b/ionos_dev/zammad/values.yaml
@@ -1,0 +1,15 @@
+zammad:
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-dev-issuer
+    hosts:
+      - host: zammad.dome-marketplace-dev.org
+        paths: 
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: zammad-tls-secret
+        hosts:
+          - zammad.dome-marketplace-dev.org

--- a/ionos_sbx/zammad/Chart.yaml
+++ b/ionos_sbx/zammad/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: zammad
+description: Chart holder for argo-cd
+
+type: application
+version: 12.0.0
+
+dependencies:
+- name: zammad
+  version: 12.0.0
+  repository: https://zammad.github.io/zammad-helm

--- a/ionos_sbx/zammad/values.yaml
+++ b/ionos_sbx/zammad/values.yaml
@@ -5,11 +5,11 @@ zammad:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-sbx-issuer
     hosts:
-      - host: zammad.dome-marketplace-dev.org
+      - host: zammad.dome-marketplace-sbx.org
         paths: 
           - path: /
             pathType: ImplementationSpecific
     tls:
       - secretName: zammad-tls-secret
         hosts:
-          - zammad.dome-marketplace-dev.org
+          - zammad.dome-marketplace-sbx.org

--- a/ionos_sbx/zammad/values.yaml
+++ b/ionos_sbx/zammad/values.yaml
@@ -1,0 +1,15 @@
+zammad:
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-sbx-issuer
+    hosts:
+      - host: zammad.dome-marketplace-dev.org
+        paths: 
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: zammad-tls-secret
+        hosts:
+          - zammad.dome-marketplace-dev.org


### PR DESCRIPTION
- added zammad.yaml under applications_dev and applications_sbx
- added zammad folder under ionos_dev and ionos_sbx
- added zammad namespace under ionos_dev/namespaces and ionos_common/namespaces