### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# to following users will be requested for
+# review when someone opens a pull request.
+*       @AdriTB-B @jaclavijo @raulmzabala 


### PR DESCRIPTION
Add Codeowners file with initially only the ElliotCloud team, to be used as default reviewers for all PRs