### PR TITLE
fix typo

### DIFF
--- a/ionos_sbx/knowledgebase/bookstack/deployment.yaml
+++ b/ionos_sbx/knowledgebase/bookstack/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: OIDC_GROUPS_CLAIM
               value: "groups"
             - name: OIDC_ADDITIONAL_SCOPES
-              value: "group"
+              value: "groups"
             - name: OIDC_REMOVE_FROM_GROUPS
               value: "true"
           ports:


### PR DESCRIPTION
missing 's' on a parameter name