### PR TITLE
SBX - cleanup default values to get up-to-date with the access-node c…

### DIFF
--- a/ionos_sbx/marketplace/access-node/values.yaml
+++ b/ionos_sbx/marketplace/access-node/values.yaml
@@ -222,24 +222,6 @@ access-node:
     nameOverride: tm-forum-api
     # -- should tm-forum-api be enabled
     enabled: true
-    ## configuration to be used by every api-deployment if nothing specific is provided.
-    defaultConfig:
-      # -- configuration to be used for the image of the containers
-      image:
-        # -- current latest tag
-        tag: "0.20.1"
-      # -- ngsi-ld broker connection information
-      ngsiLd:
-        # -- address of the broker
-        url: http://scorpio:9090
-      # -- default context to be used when contacting the context broker
-      contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
-      # -- host that the tm-forum api can be reached at, when the proxy is enabled it should be set to that address. If not, set the host for each api individually
-      serverHost: http://localhost:8080
-    ## configuration for the api proxy, to serve all apis through one kubernetes service
-    apiProxy:
-      # -- the proxy must be enabled
-      enabled: true
 
     apis:
     - name: party-catalog


### PR DESCRIPTION
The values file contained the default values of the access-node chart. Due to that, updates to the access-node components do not have an effect. 
https://github.com/DOME-Marketplace/dome-gitops/pull/457 did not increase the TMForum version due to that. 

In order to follow best practices of using helm and have an actual tested access-node deployed, the defaults have to be removed again.