### PR TITLE
SBX- remove securityContext from containers

### DIFF
--- a/ionos_sbx/bacula/bacula-dir-deployment.yaml
+++ b/ionos_sbx/bacula/bacula-dir-deployment.yaml
@@ -15,10 +15,6 @@ spec:
         app.kubernetes.io/instance: bacula-dir
         app.kubernetes.io/name: bacula-dir
     spec:
-      securityContext:
-        fsGroup: 999
-        runAsGroup: 999
-        runAsUser: 999
       containers:
         - name: bacula-dir
           image: fametec/bacula-director:11.0.5


### PR DESCRIPTION
This Pr is to fix this error 
Cannot open config file "/opt/bacula/etc/bacula-dir.conf": Permission denied

The /opt/bacula/etc directory inside the container could be created by the underlying storage provider with root ownership or permissions that conflict with the user (runAsUser: 999)

there is a solution we can do
initContainers:
- name: fix-permissions
  image: busybox
  command: ["sh", "-c", "chown -R 999:999 /opt/bacula/etc/"]
  volumeMounts:
  - name: config-volume
    mountPath: /opt/bacula/etc/
=> we can use an initContainer in the Deployment to adjust permissions before the main container starts
or 
we remove this securityContext 
Without a securityContext, the container will run using the default user defined in the container image

I suggest we remove the SecurityContext for now, to make sure everything is working and then we taccle the securityContext problems