### PR TITLE
SBX-fix pvc to readWriteMany

### DIFF
--- a/ionos_sbx/bacula/bacula-dir-pvc.yml
+++ b/ionos_sbx/bacula/bacula-dir-pvc.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: bacula
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
This Pr is to fix  the "Multi-Attach error" for the PersistentVolumeClaim (PVC), we have to modify its access mode to support multiple concurrent mounts