### PR TITLE
SBX-add-config-map to manage bacula-dir.conf

### DIFF
--- a/ionos_sbx/bacula/bacula-dir-deployment.yaml
+++ b/ionos_sbx/bacula/bacula-dir-deployment.yaml
@@ -35,9 +35,22 @@ spec:
             - name: DB_PASSWORD
               value: bacula
           volumeMounts:
-            - name: bacula-dir-volume
-              mountPath: /opt/bacula/etc
+            - name: bacula-config
+              mountPath: /opt/bacula/etc/bacula-dir.conf
+              subPath: bacula-dir.conf
+            - name: bacula-config
+              mountPath: /opt/bacula/etc/bconsole.conf
+              subPath: bconsole.conf
+            - name: bacula-dir-storage
+              mountPath: /opt/bacula/log
+            - name: bacula-dir-storage
+              mountPath: /opt/bacula/working
+            - name: bacula-dir-storage
+              mountPath: /opt/bacula/storage
       volumes:
-        - name: bacula-dir-volume
+        - name: bacula-config
+          configMap:
+            name: bacula-dir-config
+        - name: bacula-dir-storage
           persistentVolumeClaim:
             claimName: bacula-dir-pvc


### PR DESCRIPTION
Depending on the Dockerfile of fametec/bacula-director:11.0.5 
we have:
 image: fametec/bacula-director:11.0.5 
 restart: unless-stopped
 volumes: 
 - ./etc/bacula-dir.conf:/opt/bacula/etc/bacula-dir.conf:ro
 - ./etc/bconsole.conf:/opt/bacula/etc/bconsole.conf:ro 
 depends_on:
 - db 
 ports: 
 - 9101 

So, The bacula-dir.conf and bconsole.conf files should be managed by the ConfigMap and Mounted into the container at /opt/bacula/etc.