### PR TITLE
SBX- revert PVC to readWriteOnce

### DIFF
--- a/ionos_sbx/bacula/bacula-dir-pvc.yml
+++ b/ionos_sbx/bacula/bacula-dir-pvc.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: bacula
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
Revet to PVC accessMode: ReadWriteOnce (limitation IONOS) 