### PR TITLE
add pvc for db to persist data and correct bacula dire config

### DIFF
--- a/ionos_sbx/bacula/bacula-db-deployment.yaml
+++ b/ionos_sbx/bacula/bacula-db-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         app.kubernetes.io/instance: bacula-db
         app.kubernetes.io/name: bacula-db
     spec:
+      securityContext:
+        runAsUser: 0    # Root user UID
+        runAsGroup: 0   # Root group GID
+        fsGroup: 0      # Ensures mounted volumes are accessible to root
       containers:
         - name: bacula-db
           image: fametec/bacula-catalog:11.0.5
@@ -35,7 +39,10 @@ spec:
             - containerPort: 5432
               name: postgres
               protocol: TCP
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: bacula-db-pvc

--- a/ionos_sbx/bacula/bacula-db-pvc.yaml
+++ b/ionos_sbx/bacula/bacula-db-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bacula-db-pvc
+  namespace: bacula
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ionos-enterprise-hdd
+  resources:
+    requests:
+      storage: 5Gi

--- a/ionos_sbx/bacula/bacula-dir-configmap.yaml
+++ b/ionos_sbx/bacula/bacula-dir-configmap.yaml
@@ -5,16 +5,138 @@ metadata:
   namespace: bacula
 data:
   bacula-dir.conf: |
+    #
+    # Default Bacula Director Configuration file
+    #
     Director {
       Name = bacula-dir
       DIRport = 9101
-      QueryFile = "/opt/bacula/etc/query.sql"
-      Maximum Concurrent Jobs = 10
-      Password = "director-password"
-      Messages = Standard
+      QueryFile = "/opt/bacula/scripts/query.sql"
       WorkingDirectory = "/opt/bacula/working"
       PidDirectory = "/opt/bacula/working"
+      Maximum Concurrent Jobs = 20
+      Password = "XDnaVZYU9F4QhqUGMPxiOXsJaji23mNG3FaAM9Z2q1c/" # Console password
+      Messages = Daemon
     }
+
+    JobDefs {
+      Name = "DefaultJob"
+      Type = Backup
+      Level = Incremental
+      Client = bacula-fd
+      FileSet = "Full Set"
+      Schedule = "WeeklyCycle"
+      Storage = File1
+      Messages = Standard
+      Pool = File
+      SpoolAttributes = yes
+      Priority = 10
+      Write Bootstrap = "/opt/bacula/working/%c.bsr"
+    }
+
+    Job {
+      Name = "BackupClient1"
+      JobDefs = "DefaultJob"
+    }
+
+    Job {
+      Name = "BackupCatalog"
+      JobDefs = "DefaultJob"
+      Level = Full
+      FileSet="Catalog"
+      Schedule = "WeeklyCycleAfterBackup"
+      ClientRunBeforeJob = "/opt/bacula/scripts/make_catalog_backup.pl MyCatalog"
+      ClientRunAfterJob = "/opt/bacula/scripts/delete_catalog_backup"
+      Write Bootstrap = "/opt/bacula/working/%n.bsr"
+      Priority = 11
+    }
+
+    Job {
+      Name = "RestoreFiles"
+      Type = Restore
+      Client = bacula-fd
+      Storage = File1
+      FileSet="Full Set"
+      Pool = File
+      Messages = Standard
+      Where = /tmp/bacula-restores
+    }
+
+    FileSet {
+      Name = "Full Set"
+      Include {
+        Options {
+          signature = MD5
+        }
+        File = /opt/bacula/bin
+        File = /opt/bacula
+        File = /opt/bacula/etc
+      }
+      Exclude {
+        File = /opt/bacula/working
+        File = /tmp
+        File = /proc
+        File = /sys
+        File = /.journal
+        File = /.fsck
+      }
+    }
+
+    Schedule {
+      Name = "WeeklyCycle"
+      Run = Full 1st sun at 23:05
+      Run = Differential 2nd-5th sun at 23:05
+      Run = Incremental mon-sat at 23:05
+    }
+
+    Schedule {
+      Name = "WeeklyCycleAfterBackup"
+      Run = Full sun-sat at 23:10
+    }
+
+    FileSet {
+      Name = "Catalog"
+      Include {
+        Options {
+          signature = MD5
+        }
+        File = "/opt/bacula/working/bacula.sql"
+      }
+    }
+
+    Client {
+      Name = bacula-fd
+      Address = bacula-fd
+      FDPort = 9102
+      Catalog = MyCatalog
+      Password = "eso80TrxzhXkRgaQVI6ZYrSzAZ4E9KFNp0Y+T1HHVWBi"
+      File Retention = 60 days
+      Job Retention = 6 months
+      AutoPrune = yes
+    }
+
+    Autochanger {
+      Name = File1
+      Address = bacula-sd
+      SDPort = 9103
+      Password = "TS8EQJ99iLFSK39oJy33YqkZ98v4ZapjRcA+j1N6ED1n"
+      Device = FileChgr1
+      Media Type = File1
+      Maximum Concurrent Jobs = 10
+      Autochanger = File1
+    }
+
+    Autochanger {
+      Name = File2
+      Address = bacula-sd
+      SDPort = 9103
+      Password = "TS8EQJ99iLFSK39oJy33YqkZ98v4ZapjRcA+j1N6ED1n"
+      Device = FileChgr2
+      Media Type = File2
+      Autochanger = File2
+      Maximum Concurrent Jobs = 10
+    }
+
     Catalog {
       Name = MyCatalog
       dbdriver = "postgresql"
@@ -22,8 +144,58 @@ data:
       dbport = 5432
       dbname = "bacula"
       dbuser = "bacula"
-      dbpassword = "bacula-password"
+      dbpassword = "bacula"
     }
+
+    Messages {
+      Name = Standard
+      operator = root@localhost = mount
+      console = all, !skipped, !saved
+      stdout = all, !skipped
+      catalog = all
+    }
+
+    Messages {
+      Name = Daemon
+      console = all, !skipped, !saved
+      stdout = all, !skipped
+    }
+
+    Pool {
+      Name = Default
+      Pool Type = Backup
+      Recycle = yes
+      AutoPrune = yes
+      Volume Retention = 365 days
+      Maximum Volume Bytes = 50G
+      Maximum Volumes = 100
+    }
+
+    Pool {
+      Name = File
+      Pool Type = Backup
+      Recycle = yes
+      AutoPrune = yes
+      Volume Retention = 365 days
+      Maximum Volume Bytes = 50G
+      Maximum Volumes = 100
+      Label Format = "Vol-"
+    }
+
+    Pool {
+      Name = Scratch
+      Pool Type = Backup
+    }
+
+    Console {
+      Name = bacula-mon
+      Password = "r0V/Hx0TUwQ4TlnX1lyUHf8J8v9XvRBqnHTRW9+CB614"
+      CommandACL = status, .status
+    }
+
+    @/opt/bacula/etc/bacula-dir-cloud.conf
+    @/opt/bacula/etc/bacula-dir-cloud-aws.conf
+
   bconsole.conf: |
     Director {
       Name = bacula-dir


### PR DESCRIPTION
Hello 

Depending on this https://github.com/fametec/bacula/blob/3b3dbb8932a5a0167149737d38d2c3047466943a/docker/etc/bacula-dir.conf#L22
I update bacula-dir-config to ensure communcations between dir and db
- Add a pvc for bacula-db to ensure persistent data 
- run containers as root to avoid permissions issues 