### PR TITLE
SBX-fix Persistent Volume Initialization

### DIFF
--- a/ionos_sbx/bacula/bacula-db-deployment.yaml
+++ b/ionos_sbx/bacula/bacula-db-deployment.yaml
@@ -35,13 +35,27 @@ spec:
               value: "bacula"
             - name: POSTGRES_DB
               value: "bacula"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           ports:
             - containerPort: 5432
               name: postgres
               protocol: TCP
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql/data/pgdata
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+            initialDelaySeconds: 5
+            periodSeconds: 10
       volumes:
         - name: postgres-data
           persistentVolumeClaim:


### PR DESCRIPTION
The volume mounted at /var/lib/postgresql/data may already have a lost+found directory if it resides on a newly mounted filesystem. This directory interferes with PostgreSQL initialization.

Mount the volume to a subdirectory inside /var/lib/postgresql to avoid the lost+found issue.