### PR TITLE
SBX-switch to custom path

### DIFF
--- a/ionos_sbx/bacula/bacula-db-deployment.yaml
+++ b/ionos_sbx/bacula/bacula-db-deployment.yaml
@@ -36,14 +36,14 @@ spec:
             - name: POSTGRES_DB
               value: "bacula"
             - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
+              value: /mnt/data/postgres
           ports:
             - containerPort: 5432
               name: postgres
               protocol: TCP
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/postgresql/data/pgdata
+              mountPath: /mnt/data/postgres
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
Set a Custom Path to mount the volume to a different directory (e.g., /mnt/data/postgres) and set the PGDATA environment variable to point to that location. 

