### PR TITLE
SBX-fix mount path

### DIFF
--- a/ionos_sbx/bacula/bacula-db-deployment.yaml
+++ b/ionos_sbx/bacula/bacula-db-deployment.yaml
@@ -20,14 +20,17 @@ spec:
         app.kubernetes.io/instance: bacula-db
         app.kubernetes.io/name: bacula-db
     spec:
-      securityContext:
-        runAsUser: 0    # Root user UID
-        runAsGroup: 0   # Root group GID
-        fsGroup: 0      # Ensures mounted volumes are accessible to root
       containers:
         - name: bacula-db
           image: fametec/bacula-catalog:11.0.5
           imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              if [ ! "$(ls -A /mnt/data/postgres/data)" ]; then
+                initdb -D /mnt/data/postgres/data;
+              fi;
+              postgres -D /mnt/data/postgres/data;
           env:
             - name: POSTGRES_PASSWORD
               value: "bacula"
@@ -36,7 +39,7 @@ spec:
             - name: POSTGRES_DB
               value: "bacula"
             - name: PGDATA
-              value: /mnt/data/postgres
+              value: /mnt/data/postgres/data
           ports:
             - containerPort: 5432
               name: postgres


### PR DESCRIPTION
Add an entrypoint script to your container to initialize the database only if the directory is empty. 
Update the deployment to use a subdirectory for PGDATA