### PR TITLE
SBX-Update baculum-web-ingress.yaml

### DIFF
--- a/ionos_sbx/bacula/baculum-web-ingress.yaml
+++ b/ionos_sbx/bacula/baculum-web-ingress.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: bacula
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-sbx-issuer
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"  # Redirect HTTP to HTTPS
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"  # Backend is HTTP
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
Replaced nginx.ingress.kubernetes.io/ssl-passthrough with nginx.ingress.kubernetes.io/ssl-redirect: "true". This ensures that HTTP traffic is automatically redirected to HTTPS.

With these adjustments to the Ingress configuration, the Baculum Web interface should be securely accessible via HTTPS. By removing the ssl-passthrough annotation and using ssl-redirect: "true", we ensure proper SSL termination at the Ingress level, and the Web Interface will be served securely.