### PR TITLE
expose tm-forum-api services enabling ingress

### DIFF
--- a/ionos_sbx/marketplace/access-node/values.yaml
+++ b/ionos_sbx/marketplace/access-node/values.yaml
@@ -208,7 +208,6 @@ access-node:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-sbx-issuer
       hosts:
-# To Be Discussed: Jesús told us tmf subdomain in dome-marketplace-sbx.org is already created and reserved for this, but we still prefer to check it with you in case we didn´t understand this properly
         - host: tmf.dome-marketplace-sbx.org
           paths:
             - path: /
@@ -216,70 +215,65 @@ access-node:
       tls:
         - hosts:
             - tmf.dome-marketplace-sbx.org
-# To Be Discussed: how is secrets issuance managed?
           secretName: tm-forum-api-tls-secret
 
-# apis is commented as we need to use default configuration for services, following /tmf-api/<module>/v4 schema.
-# Ingress will be using this for service's requests routing.
-# At this point we don't understand why this configuration overwrite is needed,
-#  using / as base path for all tm-forum-api modules.
-#    apis:
-#    - name: party-catalog
-#      image: tmforum-party-catalog
-#      basePath: /
-#
-#    - name: customer-bill-management
-#      image: tmforum-customer-bill-management
-#      basePath: /
-#
-#    - name: customer-management
-#      image: tmforum-customer-management
-#      basePath: /
-#
-#    - name: product-catalog
-#      image: tmforum-product-catalog
-#      basePath: /
-#
-#    - name: product-inventory
-#      image: tmforum-product-inventory
-#      basePath: /
-#
-#    - name: product-ordering-management
-#      image: tmforum-product-ordering-management
-#      basePath: /
-#
-#    - name: resource-catalog
-#      image: tmforum-resource-catalog
-#      basePath: /
-#
-#    - name: resource-function-activation
-#      image: tmforum-resource-function-activation
-#      basePath: /
-#
-#    - name: resource-inventory
-#      image: tmforum-resource-inventory
-#      basePath: /
-#
-#    - name: service-catalog
-#      image: tmforum-service-catalog
-#      basePath: /
-#
-#    - name: service-inventory
-#      image: tmforum-service-inventory
-#      basePath: /
-#
-#    - name: account
-#      image: tmforum-account
-#      basePath: /
-#
-#    - name: agreement
-#      image: tmforum-agreement
-#      basePath: /
-#
-#    - name: party-role
-#      image: tmforum-party-role
-#      basePath: /
-#
-#    - name: usage-management
-#      image: tmforum-usage-management
-#      basePath: /
+    apis:
+      - name: party-catalog
+        image: tmforum-party-catalog
+        basePath: /tmf-api/party/v4
+
+      - name: customer-bill-management
+        image: tmforum-customer-bill-management
+        basePath: /tmf-api/customerBillManagement/v4
+
+      - name: customer-management
+        image: tmforum-customer-management
+        basePath: /tmf-api/customerManagement/v4
+
+      - name: product-catalog
+        image: tmforum-product-catalog
+        basePath: /tmf-api/productCatalogManagement/v4
+
+      - name: product-inventory
+        image: tmforum-product-inventory
+        basePath: /tmf-api/productInventory/v4
+
+      - name: product-ordering-management
+        image: tmforum-product-ordering-management
+        basePath: /tmf-api/productOrderingManagement/v4
+
+      - name: resource-catalog
+        image: tmforum-resource-catalog
+        basePath: /tmf-api/resourceCatalog/v4
+
+      - name: resource-function-activation
+        image: tmforum-resource-function-activation
+        basePath: /tmf-api/resourceFunctionActivation/v4
+
+      - name: resource-inventory
+        image: tmforum-resource-inventory
+        basePath: /tmf-api/resourceInventoryManagement/v4
+
+      - name: service-catalog
+        image: tmforum-service-catalog
+        basePath: /tmf-api/serviceCatalogManagement/v4
+
+      - name: service-inventory
+        image: tmforum-service-inventory
+        basePath: /tmf-api/serviceInventory/v4
+
+      - name: account-management
+        image: tmforum-account
+        basePath: /tmf-api/accountManagement/v4
+
+      - name: agreement-management
+        image: tmforum-agreement
+        basePath: /tmf-api/agreementManagement/v4
+
+      - name: party-role
+        image: tmforum-party-role
+        basePath: /tmf-api/partyRoleManagement/v4
+
+      - name: usage-management
+        image: tmforum-usage-management
+        basePath: /tmf-api/usageManagement/v4

--- a/ionos_sbx/marketplace/access-node/values.yaml
+++ b/ionos_sbx/marketplace/access-node/values.yaml
@@ -202,63 +202,84 @@ access-node:
       - name: API_EXTENSION_ENABLED
         value: "true"
 
-    apis:
-    - name: party-catalog
-      image: tmforum-party-catalog
-      basePath: /
+    ingress:
+      enabled: true
+      className: nginx
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-sbx-issuer
+      hosts:
+# To Be Discussed: Jesús told us tmf subdomain in dome-marketplace-sbx.org is already created and reserved for this, but we still prefer to check it with you in case we didn´t understand this properly
+        - host: tmf.dome-marketplace-sbx.org
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - hosts:
+            - tmf.dome-marketplace-sbx.org
+# To Be Discussed: how is secrets issuance managed?
+          secretName: tm-forum-api-tls-secret
 
-    - name: customer-bill-management
-      image: tmforum-customer-bill-management
-      basePath: /
-
-    - name: customer-management
-      image: tmforum-customer-management
-      basePath: /
-
-    - name: product-catalog
-      image: tmforum-product-catalog
-      basePath: /
-
-    - name: product-inventory
-      image: tmforum-product-inventory
-      basePath: /
-
-    - name: product-ordering-management
-      image: tmforum-product-ordering-management
-      basePath: /
-
-    - name: resource-catalog
-      image: tmforum-resource-catalog
-      basePath: /
-
-    - name: resource-function-activation
-      image: tmforum-resource-function-activation
-      basePath: /
-
-    - name: resource-inventory
-      image: tmforum-resource-inventory
-      basePath: /
-
-    - name: service-catalog
-      image: tmforum-service-catalog
-      basePath: /
-
-    - name: service-inventory
-      image: tmforum-service-inventory
-      basePath: /
-
-    - name: account
-      image: tmforum-account
-      basePath: /
-
-    - name: agreement
-      image: tmforum-agreement
-      basePath: /
-
-    - name: party-role
-      image: tmforum-party-role
-      basePath: /
-
-    - name: usage-management
-      image: tmforum-usage-management
-      basePath: / 
+# apis is commented as we need to use default configuration for services, following /tmf-api/<module>/v4 schema.
+# Ingress will be using this for service's requests routing.
+# At this point we don't understand why this configuration overwrite is needed,
+#  using / as base path for all tm-forum-api modules.
+#    apis:
+#    - name: party-catalog
+#      image: tmforum-party-catalog
+#      basePath: /
+#
+#    - name: customer-bill-management
+#      image: tmforum-customer-bill-management
+#      basePath: /
+#
+#    - name: customer-management
+#      image: tmforum-customer-management
+#      basePath: /
+#
+#    - name: product-catalog
+#      image: tmforum-product-catalog
+#      basePath: /
+#
+#    - name: product-inventory
+#      image: tmforum-product-inventory
+#      basePath: /
+#
+#    - name: product-ordering-management
+#      image: tmforum-product-ordering-management
+#      basePath: /
+#
+#    - name: resource-catalog
+#      image: tmforum-resource-catalog
+#      basePath: /
+#
+#    - name: resource-function-activation
+#      image: tmforum-resource-function-activation
+#      basePath: /
+#
+#    - name: resource-inventory
+#      image: tmforum-resource-inventory
+#      basePath: /
+#
+#    - name: service-catalog
+#      image: tmforum-service-catalog
+#      basePath: /
+#
+#    - name: service-inventory
+#      image: tmforum-service-inventory
+#      basePath: /
+#
+#    - name: account
+#      image: tmforum-account
+#      basePath: /
+#
+#    - name: agreement
+#      image: tmforum-agreement
+#      basePath: /
+#
+#    - name: party-role
+#      image: tmforum-party-role
+#      basePath: /
+#
+#    - name: usage-management
+#      image: tmforum-usage-management
+#      basePath: /

--- a/ionos_sbx/marketplace/access-node/values.yaml
+++ b/ionos_sbx/marketplace/access-node/values.yaml
@@ -262,11 +262,11 @@ access-node:
         image: tmforum-service-inventory
         basePath: /tmf-api/serviceInventory/v4
 
-      - name: account-management
+      - name: account
         image: tmforum-account
         basePath: /tmf-api/accountManagement/v4
 
-      - name: agreement-management
+      - name: agreement
         image: tmforum-agreement
         basePath: /tmf-api/agreementManagement/v4
 

--- a/ionos_sbx/marketplace/access-node/values.yaml
+++ b/ionos_sbx/marketplace/access-node/values.yaml
@@ -218,62 +218,62 @@ access-node:
           secretName: tm-forum-api-tls-secret
 
     apis:
-      - name: party-catalog
-        image: tmforum-party-catalog
-        basePath: /tmf-api/party/v4
+    - name: party-catalog
+      image: tmforum-party-catalog
+      basePath: /tmf-api/party/v4
 
-      - name: customer-bill-management
-        image: tmforum-customer-bill-management
-        basePath: /tmf-api/customerBillManagement/v4
+    - name: customer-bill-management
+      image: tmforum-customer-bill-management
+      basePath: /tmf-api/customerBillManagement/v4
 
-      - name: customer-management
-        image: tmforum-customer-management
-        basePath: /tmf-api/customerManagement/v4
+    - name: customer-management
+      image: tmforum-customer-management
+      basePath: /tmf-api/customerManagement/v4
 
-      - name: product-catalog
-        image: tmforum-product-catalog
-        basePath: /tmf-api/productCatalogManagement/v4
+    - name: product-catalog
+      image: tmforum-product-catalog
+      basePath: /tmf-api/productCatalogManagement/v4
 
-      - name: product-inventory
-        image: tmforum-product-inventory
-        basePath: /tmf-api/productInventory/v4
+    - name: product-inventory
+      image: tmforum-product-inventory
+      basePath: /tmf-api/productInventory/v4
 
-      - name: product-ordering-management
-        image: tmforum-product-ordering-management
-        basePath: /tmf-api/productOrderingManagement/v4
+    - name: product-ordering-management
+      image: tmforum-product-ordering-management
+      basePath: /tmf-api/productOrderingManagement/v4
 
-      - name: resource-catalog
-        image: tmforum-resource-catalog
-        basePath: /tmf-api/resourceCatalog/v4
+    - name: resource-catalog
+      image: tmforum-resource-catalog
+      basePath: /tmf-api/resourceCatalog/v4
 
-      - name: resource-function-activation
-        image: tmforum-resource-function-activation
-        basePath: /tmf-api/resourceFunctionActivation/v4
+    - name: resource-function-activation
+      image: tmforum-resource-function-activation
+      basePath: /tmf-api/resourceFunctionActivation/v4
 
-      - name: resource-inventory
-        image: tmforum-resource-inventory
-        basePath: /tmf-api/resourceInventoryManagement/v4
+    - name: resource-inventory
+      image: tmforum-resource-inventory
+      basePath: /tmf-api/resourceInventoryManagement/v4
 
-      - name: service-catalog
-        image: tmforum-service-catalog
-        basePath: /tmf-api/serviceCatalogManagement/v4
+    - name: service-catalog
+      image: tmforum-service-catalog
+      basePath: /tmf-api/serviceCatalogManagement/v4
 
-      - name: service-inventory
-        image: tmforum-service-inventory
-        basePath: /tmf-api/serviceInventory/v4
+    - name: service-inventory
+      image: tmforum-service-inventory
+      basePath: /tmf-api/serviceInventory/v4
 
-      - name: account
-        image: tmforum-account
-        basePath: /tmf-api/accountManagement/v4
+    - name: account
+      image: tmforum-account
+      basePath: /tmf-api/accountManagement/v4
 
-      - name: agreement
-        image: tmforum-agreement
-        basePath: /tmf-api/agreementManagement/v4
+    - name: agreement
+      image: tmforum-agreement
+      basePath: /tmf-api/agreementManagement/v4
 
-      - name: party-role
-        image: tmforum-party-role
-        basePath: /tmf-api/partyRoleManagement/v4
+    - name: party-role
+      image: tmforum-party-role
+      basePath: /tmf-api/partyRoleManagement/v4
 
-      - name: usage-management
-        image: tmforum-usage-management
-        basePath: /tmf-api/usageManagement/v4
+    - name: usage-management
+      image: tmforum-usage-management
+      basePath: /tmf-api/usageManagement/v4

--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -8,43 +8,43 @@ business-api-ecosystem:
       catalog:
         host: tm-forum-api-product-catalog
         port: 8080
-        path: 
+        path: /tmf-api/productCatalogManagement/v4
       inventory:
         host: tm-forum-api-product-inventory
         port: 8080
-        path: 
+        path: /tmf-api/productInventory/v4
       ordering:
         host: tm-forum-api-product-ordering-management
         port: 8080
-        path: 
+        path: /tmf-api/productOrderingManagement/v4
       billing:
         host: tm-forum-api-account
         port: 8080
-        path:
+        path: /tmf-api/accountManagement/v4
       usage:
         host: tm-forum-api-usage-management
         port: 8080
-        path: 
+        path: /tmf-api/usageManagement/v4
       party:
         host: tm-forum-api-party-catalog
         port: 8080
-        path: 
+        path: /tmf-api/party/v4
       customer:
         host: tm-forum-api-customer-management
         port: 8080
-        path: 
+        path: /tmf-api/customerManagement/v4
       resources:
         host: tm-forum-api-resource-catalog
         port: 8080
-        path: 
+        path: /tmf-api/resourceCatalog/v4
       services:
         host: tm-forum-api-service-catalog
         port: 8080
-        path: 
+        path: /tmf-api/serviceCatalogManagement/v4
       resourceInventory:
         host: tm-forum-api-resource-inventory
         port: 8080
-        path:
+        path: /tmf-api/resourceInventoryManagement/v4
 
   bizEcosystemRss:
     enabled: false


### PR DESCRIPTION
Hello guys,

I open PR to expose TMForum API services through the domain name tmf.dome-marketplace-sbx.org.

The contribution is not ready to be merged. Before we would like to discuss some points. The current commit includes comments with issues to be addressed before it is closed. When we are clear I will make a new commit deleting the comments.

1. Domain name → tmf.dome-marketplace-sbx.org. We have talked to Jesus Ruiz and he told us that this subdomain was already generated to expose these services. Can you verify that we can use it?

2. Generation of the cryptographic material: At this moment we do not know how to generate the certificate and private key needed to expose the services.  We see that a letsencrypt-sbx-issuer tag is added, but we don't know exactly if this generates the certificates if you or we would have to generate them, or in which secret this information is stored.

3. Rewrite the default APIs in the service. We see that the basepath of the services has been modified and we do not understand why. Maybe you are only in charge of the deployment and you do not have this information, but it seems to us a potential point of failure not to understand it.

We put ourselves at your disposal in what we can help to close this functionality.
Thanks in advance 