### PR TITLE
SBX - Revert the paths to TMForum internal services for the BAE

### DIFF
--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -8,43 +8,43 @@ business-api-ecosystem:
       catalog:
         host: tm-forum-api-product-catalog
         port: 8080
-        path: /tmf-api/productCatalogManagement/v4
+        path:
       inventory:
         host: tm-forum-api-product-inventory
         port: 8080
-        path: /tmf-api/productInventory/v4
+        path:
       ordering:
         host: tm-forum-api-product-ordering-management
         port: 8080
-        path: /tmf-api/productOrderingManagement/v4
+        path:
       billing:
         host: tm-forum-api-account
         port: 8080
-        path: /tmf-api/accountManagement/v4
+        path:
       usage:
         host: tm-forum-api-usage-management
         port: 8080
-        path: /tmf-api/usageManagement/v4
+        path:
       party:
         host: tm-forum-api-party-catalog
         port: 8080
-        path: /tmf-api/party/v4
+        path:
       customer:
         host: tm-forum-api-customer-management
         port: 8080
-        path: /tmf-api/customerManagement/v4
+        path:
       resources:
         host: tm-forum-api-resource-catalog
         port: 8080
-        path: /tmf-api/resourceCatalog/v4
+        path:
       services:
         host: tm-forum-api-service-catalog
         port: 8080
-        path: /tmf-api/serviceCatalogManagement/v4
+        path:
       resourceInventory:
         host: tm-forum-api-resource-inventory
         port: 8080
-        path: /tmf-api/resourceInventoryManagement/v4
+        path:
 
   bizEcosystemRss:
     enabled: false

--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -1,6 +1,6 @@
 business-api-ecosystem:
   bizEcosystemApis:
-    # should set the path to the new apis.
+    # Reverted the paths to empty strings
     fullnameOverride: tmforum-api-proxy
     enabled: false
 


### PR DESCRIPTION
This PR reverts the paths to TMForum internal services for the BAE, which had been modifier by the previous PR #1277.