### PR TITLE
SBX - Set the base path for BAE to a single '/'

### DIFF
--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -8,43 +8,43 @@ business-api-ecosystem:
       catalog:
         host: tm-forum-api-product-catalog
         port: 8080
-        path:
+        path: /
       inventory:
         host: tm-forum-api-product-inventory
         port: 8080
-        path:
+        path: /
       ordering:
         host: tm-forum-api-product-ordering-management
         port: 8080
-        path:
+        path: /
       billing:
         host: tm-forum-api-account
         port: 8080
-        path:
+        path: /
       usage:
         host: tm-forum-api-usage-management
         port: 8080
-        path:
+        path: /
       party:
         host: tm-forum-api-party-catalog
         port: 8080
-        path:
+        path: /
       customer:
         host: tm-forum-api-customer-management
         port: 8080
-        path:
+        path: /
       resources:
         host: tm-forum-api-resource-catalog
         port: 8080
-        path:
+        path: /
       services:
         host: tm-forum-api-service-catalog
         port: 8080
-        path:
+        path: /
       resourceInventory:
         host: tm-forum-api-resource-inventory
         port: 8080
-        path:
+        path: /
 
   bizEcosystemRss:
     enabled: false


### PR DESCRIPTION
I made an error in my previous PR. This new PR sets the paths for the BAE to a single `/`.