### PR TITLE
SBX - Payment Scheduler Ingress

### DIFF
--- a/ionos_sbx/billing/payment-scheduler/ingress.yaml
+++ b/ionos_sbx/billing/payment-scheduler/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: payment-scheduler-ingress
+  namespace: billing
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-sbx-issuer
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: payment.dome-marketplace-sbx.org
+    http:
+      paths:
+      - path: /payment/notify
+        pathType: Prefix
+        backend:
+          service:
+            name: payment-scheduler-svc
+            port:
+              number: 8080
+  tls:
+  - hosts:
+    - payment.dome-marketplace-sbx.org
+    secretName: payment-scheduler-tls-secret


### PR DESCRIPTION
Please, could you add my Ingress for the payment-scheduler service in SBX?
I have to expose the path **https://payment.dome-marketplace-sbx.org/payment/notify** for external usage.
I used **payment.dome-marketplace-sbx.org** host and **/payment/notify** path.

Many thanks