### PR TITLE
SBX - Use proper secret key in BAE config

### DIFF
--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -143,6 +143,8 @@ business-api-ecosystem:
       method: dpas
 
     existingSecret: bae-secret
+    secretName: bae-secret
+
     db: 
       host: mongodb
       database: charging_db


### PR DESCRIPTION
This PR updates the bae using the proper configuration name for the BAE secret