### PR TITLE
SBX - Enable email password to be read in BAE config

### DIFF
--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -159,6 +159,7 @@ business-api-ecosystem:
         user: customer-service@dome-marketplace.eu
         ## -- SMTP server hostname
         server: smtp.ionos.de
+        password: true
 
     backup:
       enabled: false


### PR DESCRIPTION
This PR updates the BAE config in sandbox enabling the email password to be read from the secret