### PR TITLE
SBX - Dissable CCS in BAE config

### DIFF
--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -67,6 +67,7 @@ business-api-ecosystem:
       - admin
     # Configuration for the Credential Config Service initiation
     ccs:
+      enabled: false
       endpoint: "http://credentials-config-service:8080"
       defaultOidcScope: "defaultScope"
       # -- Credential configurations for particular scopes


### PR DESCRIPTION
This PR disables the CCS config from the SBX BAE