### PR TITLE
PRD: Add missing resource requests to marketplace pods

### DIFF
--- a/ionos_prd/marketplace/access-node/values.yaml
+++ b/ionos_prd/marketplace/access-node/values.yaml
@@ -10,6 +10,13 @@ access-node:
       # Overrides the image tag whose default is the chart appVersion.
       tag: v2.0.3
       pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "512Mi"
+      limits:
+        cpu: "500m"
+        memory: "768Mi"
     readinessProbe:
       failureThreshold: 10
     livenessProbe:
@@ -124,6 +131,14 @@ access-node:
   scorpio:
     # -- should scorpio be enabled
     enabled: true
+    ## resource requests/limits
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "1Gi"
+      limits:
+        cpu: "500m"
+        memory: "1536Mi"
     ## configuration of the image to be used
     image:
       # -- repository to be used - resource friendly all-in-one-runner without kafka
@@ -219,6 +234,14 @@ access-node:
         # -- current latest tag
         tag: "sbx_1.5.4"
         pullPolicy: IfNotPresent
+      # -- resource requests/limits applied to all TM Forum API pods
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "512Mi"
+        limits:
+          cpu: "500m"
+          memory: "1Gi"
       additionalEnvVars:
         - name: API_EXTENSION_ENABLED
           value: "true"

--- a/ionos_prd/marketplace/bae/values.yaml
+++ b/ionos_prd/marketplace/bae/values.yaml
@@ -141,6 +141,14 @@ business-api-ecosystem:
     
     port: 8006
 
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+
     loglevel: debug
 
     payment:
@@ -209,6 +217,14 @@ business-api-ecosystem:
 
     port: 8004
     nodeEnvironment: production
+
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "384Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
 
     db:
       host: mongodb

--- a/ionos_prd/marketplace/connector/dlt-adapter/deployment.yaml
+++ b/ionos_prd/marketplace/connector/dlt-adapter/deployment.yaml
@@ -26,6 +26,13 @@ spec:
         - image: aleniet/dlt-adapter:1.1
           imagePullPolicy: IfNotPresent
           name: dlt-adapter
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "384Mi"
           env:
             - name: PRIVATE_KEY
               value: 0xe2afef2c880b138d741995ba56936e389b0b5dd2943e21e4363cc70d81c89346

--- a/ionos_prd/marketplace/iam/credentials-config-service/values.yaml
+++ b/ionos_prd/marketplace/iam/credentials-config-service/values.yaml
@@ -2,9 +2,18 @@ credentials-config-service:
 
   # Image
   deployment:
-    image: 
+    image:
       repository: quay.io/fiware/credentials-config-service
       tag: 1.0.1
+
+  # Resources
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "384Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
 
   # Database config
   database:

--- a/ionos_prd/marketplace/iam/trusted-issuers-list/values.yaml
+++ b/ionos_prd/marketplace/iam/trusted-issuers-list/values.yaml
@@ -2,8 +2,17 @@ trusted-issuers-list:
 
   # Image
   deployment:
-    image:  
+    image:
       tag: 0.2.0
+
+  # Resources
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "384Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
 
   # Configure an Ingress or OpenShift Route
   ingress:

--- a/ionos_prd/marketplace/iam/vcwaltid/templates/deployment.yaml
+++ b/ionos_prd/marketplace/iam/vcwaltid/templates/deployment.yaml
@@ -23,6 +23,13 @@ spec:
         - name: {{ .Chart.Name }}
           imagePullPolicy: Always
           image: "lipanski/docker-static-website:2.1.0"
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           ports:
             - name: http
               containerPort: 3000

--- a/ionos_prd/marketplace/iam/vcwaltid/values.yaml
+++ b/ionos_prd/marketplace/iam/vcwaltid/values.yaml
@@ -20,6 +20,15 @@ vcwaltid:
       tag: 1.14.1-SNAPSHOT
       pullPolicy: Always
 
+  # Resources
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "300Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
   # API config
   api:
     core: 

--- a/ionos_prd/marketplace/iam/verifier/values.yaml
+++ b/ionos_prd/marketplace/iam/verifier/values.yaml
@@ -4,6 +4,14 @@ dome-verifier:
     tag: v2.0.12
     pullPolicy: IfNotPresent
 
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "640Mi"
+
   ingress:
     enabled: true
     className: nginx

--- a/ionos_prd/marketplace/tailored-offerings/deployment.yaml
+++ b/ionos_prd/marketplace/tailored-offerings/deployment.yaml
@@ -18,6 +18,13 @@ spec:
       containers:
         - name: quote-management-container
           image: production.eng.it:8433/dome/quote_management_backend:1.3.22
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "400Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
           env:
             - name: TMFORUM_API_BASE_URL
               value: http://tm-forum-api-quote.marketplace.svc.cluster.local:8080/tmf-api


### PR DESCRIPTION
## Summary

- Add resource requests/limits to **all remaining marketplace pods** that had none set
- Also fixes 2 items from PR #2491 that didn't take effect: **scorpio** and **tmforum-api** were edited in standalone files but are actually deployed via the `access-node` Helm chart

## Resource values based on 30-day Prometheus monitoring data

All values derived from `max_over_time(...[30d:1h])` queries against the dome-prod Prometheus instance (30d retention). CPU requests set with headroom for scheduling; memory limits set above 30-day peaks to prevent OOMKill.

| Component | 30d Max CPU | CPU Request | 30d Max Mem | Mem Request | Mem Limit |
|---|---|---|---|---|---|
| BAE charging-backend | 10m | 50m | 79Mi | 128Mi | 256Mi |
| BAE logic-proxy | 100m | 50m | 331Mi | 384Mi | 512Mi |
| credentials-config-service | 7m | 50m | 332Mi | 384Mi | 512Mi |
| trusted-issuers-list | 164m | 50m | 314Mi | 384Mi | 512Mi |
| **verifier** | **264m** | **100m** | **476Mi** | **512Mi** | **640Mi** |
| vcwaltid (main) | 2m | 50m | 272Mi | 300Mi | 512Mi |
| vcwaltid-certs (static) | ~0m | 10m | ~0Mi | 32Mi | 64Mi |
| desmos | 26m | 50m | 587Mi | 512Mi | 768Mi |
| dlt-adapter | 7m | 50m | 236Mi | 256Mi | 384Mi |
| quote-management | 9m | 50m | 381Mi | 400Mi | 512Mi |
| **scorpio** | **94m** | **50m** | **1026Mi** | **1Gi** | **1536Mi** |
| tmforum-api (x15 pods) | 2-5m each | 50m each | 277-913Mi | 512Mi | 1Gi |

**Note:** Verifier had the highest CPU spike (264m) of all marketplace pods in the last 30 days, so it gets a higher CPU request (100m) and generous memory limit (640Mi) compared to others.

## Why

PR #2491 added requests to the biggest offenders but:
1. Scorpio and tmforum-api edits went to unused standalone files — both are actually deployed via the `access-node` Helm chart. Verified by checking `argocd.argoproj.io/instance: access-node` labels on the live deployments.
2. Many marketplace pods (BAE, IAM stack, connectors) still had zero requests, making them invisible to the scheduler.

## Files changed

| File | Components affected |
|---|---|
| `access-node/values.yaml` | desmos, scorpio, tmforum-api (x15) |
| `bae/values.yaml` | charging-backend, logic-proxy |
| `iam/credentials-config-service/values.yaml` | credentials-config-service |
| `iam/trusted-issuers-list/values.yaml` | trusted-issuers-list |
| `iam/verifier/values.yaml` | verifier |
| `iam/vcwaltid/values.yaml` | vcwaltid main |
| `iam/vcwaltid/templates/deployment.yaml` | vcwaltid-certs |
| `connector/dlt-adapter/deployment.yaml` | dlt-adapter |
| `tailored-offerings/deployment.yaml` | quote-management |

## Test plan

- [x] Verify ArgoCD apps sync without errors: `access-node`, `bae-marketplace`, `credentials-config-service`, `trusted-issuers-list`, `verifier-marketplace`, `walt-id`, `tailored-offerings`
- [x] Check `kubectl get pods -n marketplace -o jsonpath` confirms resources are non-empty on all pods
- [x] Monitor for OOMKill or CrashLoopBackOff after rollout
- [x] Verify `kubectl describe nodes` shows updated request totals