### PR TITLE
PRD: Add pod anti-affinity to spread critical services across nodes

### DIFF
--- a/ionos_prd/argocd/values.yaml
+++ b/ionos_prd/argocd/values.yaml
@@ -25,6 +25,15 @@ redis-ha:
 
 controller:
   replicas: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: server
+            topologyKey: kubernetes.io/hostname
   metrics:
     enabled: true
     serviceMonitor:
@@ -32,6 +41,15 @@ controller:
 
 server:
   replicas: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: repo-server
+            topologyKey: kubernetes.io/hostname
   ingress:
     enabled: true
     hostname: argocd.dome-marketplace-prd.org
@@ -48,6 +66,15 @@ server:
 
 repoServer:
   replicas: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: application-controller
+            topologyKey: kubernetes.io/hostname
   metrics:
     enabled: true
     serviceMonitor:

--- a/ionos_prd/cs-identity/values.yaml
+++ b/ionos_prd/cs-identity/values.yaml
@@ -1,4 +1,15 @@
 keycloak:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: primary
+            namespaces:
+              - cs-identity
+            topologyKey: kubernetes.io/hostname
   image:
     repository: bitnamilegacy/keycloak
     tag: 24.0.4-debian-12-r1

--- a/ionos_prd/marketplace/iam/mysql/values.yaml
+++ b/ionos_prd/marketplace/iam/mysql/values.yaml
@@ -12,6 +12,21 @@ mysql:
       CREATE DATABASE ccs;
       
   primary:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - mongodb
+                      - scorpio
+              namespaces:
+                - marketplace
+              topologyKey: kubernetes.io/hostname
     podAnnotations:
       backup.velero.io/backup-volumes: data
 

--- a/ionos_prd/zammad/values.yaml
+++ b/ionos_prd/zammad/values.yaml
@@ -112,3 +112,13 @@ zammad:
       limits:
         cpu: 250m
         memory: 256Mi
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: zammad
+          topologyKey: kubernetes.io/hostname

--- a/ionos_prd/zammad2/values.yaml
+++ b/ionos_prd/zammad2/values.yaml
@@ -112,3 +112,13 @@ zammad:
       limits:
         cpu: 250m
         memory: 256Mi
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: zammad2
+          topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary

Add soft pod anti-affinity rules to prevent critical services from clustering on a single node. This directly addresses the root cause of the Apr 7 production outage.

## Problem

On 2026-04-07, node `dome-prd-pool-qckgmkhc2d` became overloaded because too many critical services were co-located on it. When it started thrashing, it caused cascading failures across marketplace (MongoDB, MySQL-TIL, Scorpio), ArgoCD (repo-server, server), and Loki (all components).

**Current distribution still has this risk.** For example, node `3k7dxxwgqt` currently hosts:
- `mysql-til` (marketplace DB)
- `scorpio` (context broker) 
- `in2/keycloak` (wallet auth)
- `argocd-server` + `argocd-repo-server` (GitOps)

If this node fails, both the marketplace and GitOps are impacted simultaneously.

## Changes

All rules use **`preferredDuringSchedulingIgnoredDuringExecution`** (soft preference) so pods can still schedule on the same node if cluster capacity is limited — they won't get stuck in Pending.

| Component | Anti-affinity rule | Effect |
|---|---|---|
| **ArgoCD controller** | Prefer different node from `server` | Controller + server on separate nodes |
| **ArgoCD server** | Prefer different node from `repo-server` | Server + repo-server on separate nodes |
| **ArgoCD repo-server** | Prefer different node from `controller` | Repo-server + controller on separate nodes |
| **cs-identity/keycloak** | Prefer different node from `postgresql` | Auth app + its DB on separate nodes |
| **marketplace/mysql-til** | Prefer different node from `mongodb` and `scorpio` | Marketplace databases spread out |
| **zammad (all pods)** | Prefer spreading across nodes | Railsserver replicas on different nodes |
| **zammad2 (all pods)** | Prefer spreading across nodes | Railsserver replicas on different nodes |

## Why soft (preferred) instead of hard (required)?

With only 4 worker nodes and many services, hard anti-affinity could cause pods to get stuck in `Pending` if there aren't enough nodes to satisfy all constraints. Soft preference is the right tradeoff — the scheduler will spread pods across nodes when possible, but won't block scheduling if it can't.

## Test plan

- [x] Verify ArgoCD syncs without errors for: `argocd`, `cs-identity`, `mysql`, `zammad`, `zammad2`
- [x] Check pod distribution: `kubectl get pods -o wide` — confirm affected pods are on different nodes where possible
- [x] Verify no pods stuck in `Pending` due to unsatisfiable affinity rules
- [x] After next node drain/restart, confirm the scheduler re-distributes pods across nodes

## Related

- #2491 — Right-sized resource requests (merged)
- #2492 — Added missing resource requests to marketplace (merged)
- #2497 — PDB + HA investigation (issue, requires replica scaling first)