### PR TITLE
PRD: add Weekly Capacity Management Grafana dashboard

### DIFF
--- a/ionos_prd/grafana-dashboards/namespace-compliance-overview.yaml
+++ b/ionos_prd/grafana-dashboards/namespace-compliance-overview.yaml
@@ -1,0 +1,899 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: namespace-compliance-overview
+data:
+  namespace-compliance-overview.json: |-
+      {
+        "title": "Namespace Compliance Overview",
+        "description": "Per-namespace resource compliance with cluster context. All values averaged over the selected time range.",
+        "tags": [
+          "dome",
+          "capacity",
+          "compliance"
+        ],
+        "timezone": "browser",
+        "schemaVersion": 39,
+        "editable": true,
+        "fiscalYearStartMonth": 0,
+        "graphTooltip": 0,
+        "refresh": "1m",
+        "time": {
+          "from": "now-7d",
+          "to": "now"
+        },
+        "timepicker": {},
+        "templating": {
+          "list": [
+            {
+              "name": "category",
+              "label": "Namespace categories",
+              "description": "Application = DOME-built workloads. Infrastructure = ops/monitoring/GitOps. System = Kubernetes core. By default Application + Infrastructure are selected; tick System to include kube-system, default, etc.",
+              "type": "custom",
+              "multi": true,
+              "includeAll": false,
+              "options": [
+                {
+                  "text": "Application",
+                  "value": "analytics|billing|chatbot|cs-identity|digitelts|dome-certification|dome-trust|echoserver|in2|knowledgebase|marketplace|search-engine|til|tst01|zammad|zammad2",
+                  "selected": true
+                },
+                {
+                  "text": "Infrastructure",
+                  "value": "argocd|cert-manager|external-dns|falco|ingress-nginx|kube-prometheus-stack|loki-distributed|promtail|sealed-secrets|velero",
+                  "selected": true
+                },
+                {
+                  "text": "System",
+                  "value": "kube-system|kube-public|kube-node-lease|default",
+                  "selected": false
+                }
+              ],
+              "current": {
+                "selected": true,
+                "text": [
+                  "Application",
+                  "Infrastructure"
+                ],
+                "value": [
+                  "analytics|billing|chatbot|cs-identity|digitelts|dome-certification|dome-trust|echoserver|in2|knowledgebase|marketplace|search-engine|til|tst01|zammad|zammad2",
+                  "argocd|cert-manager|external-dns|falco|ingress-nginx|kube-prometheus-stack|loki-distributed|promtail|sealed-secrets|velero"
+                ]
+              },
+              "query": "Application : analytics|billing|chatbot|cs-identity|digitelts|dome-certification|dome-trust|echoserver|in2|knowledgebase|marketplace|search-engine|til|tst01|zammad|zammad2, Infrastructure : argocd|cert-manager|external-dns|falco|ingress-nginx|kube-prometheus-stack|loki-distributed|promtail|sealed-secrets|velero, System : kube-system|kube-public|kube-node-lease|default",
+              "hide": 0,
+              "skipUrlSync": false
+            }
+          ]
+        },
+        "annotations": {
+          "list": []
+        },
+        "panels": [
+          {
+            "id": 1,
+            "type": "stat",
+            "title": "Cluster CPU requested (avg)",
+            "gridPos": {
+              "x": 0,
+              "y": 0,
+              "w": 4,
+              "h": 6
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "targets": [
+              {
+                "expr": "avg_over_time((sum(kube_pod_container_resource_requests{resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"}))[$__range:5m])",
+                "refId": "A",
+                "instant": true,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "unit": "percentunit",
+                "decimals": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.7
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.85
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "thresholds"
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background",
+              "textMode": "auto",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              }
+            }
+          },
+          {
+            "id": 2,
+            "type": "stat",
+            "title": "Cluster CPU used (avg)",
+            "gridPos": {
+              "x": 4,
+              "y": 0,
+              "w": 4,
+              "h": 6
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "targets": [
+              {
+                "expr": "avg_over_time((sum(rate(container_cpu_usage_seconds_total{container!=\"POD\",container!=\"\"}[5m])) / sum(kube_node_status_allocatable{resource=\"cpu\"}))[$__range:5m])",
+                "refId": "A",
+                "instant": true,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "unit": "percentunit",
+                "decimals": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.6
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.85
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "thresholds"
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background",
+              "textMode": "auto",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              }
+            }
+          },
+          {
+            "id": 3,
+            "type": "stat",
+            "title": "Cluster Memory requested (avg)",
+            "gridPos": {
+              "x": 8,
+              "y": 0,
+              "w": 4,
+              "h": 6
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "targets": [
+              {
+                "expr": "avg_over_time((sum(kube_pod_container_resource_requests{resource=\"memory\"}) / sum(kube_node_status_allocatable{resource=\"memory\"}))[$__range:5m])",
+                "refId": "A",
+                "instant": true,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "unit": "percentunit",
+                "decimals": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.7
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.85
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "thresholds"
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background",
+              "textMode": "auto",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              }
+            }
+          },
+          {
+            "id": 4,
+            "type": "stat",
+            "title": "Cluster Memory used (avg)",
+            "gridPos": {
+              "x": 12,
+              "y": 0,
+              "w": 4,
+              "h": 6
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "targets": [
+              {
+                "expr": "avg_over_time((sum(container_memory_working_set_bytes{container!=\"POD\",container!=\"\"}) / sum(kube_node_status_allocatable{resource=\"memory\"}))[$__range:5m])",
+                "refId": "A",
+                "instant": true,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "unit": "percentunit",
+                "decimals": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.6
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.85
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "thresholds"
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background",
+              "textMode": "auto",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              }
+            }
+          },
+          {
+            "id": 5,
+            "type": "stat",
+            "title": "Cluster Storage used (avg)",
+            "gridPos": {
+              "x": 16,
+              "y": 0,
+              "w": 4,
+              "h": 6
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "targets": [
+              {
+                "expr": "avg_over_time((sum(kubelet_volume_stats_used_bytes) / sum(kubelet_volume_stats_capacity_bytes))[$__range:5m])",
+                "refId": "A",
+                "instant": true,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "unit": "percentunit",
+                "decimals": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "orange",
+                      "value": 0.8
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.95
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "thresholds"
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background",
+              "textMode": "auto",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              }
+            }
+          },
+          {
+            "id": 6,
+            "type": "stat",
+            "title": "N-1 CPU pressure (avg)",
+            "gridPos": {
+              "x": 20,
+              "y": 0,
+              "w": 4,
+              "h": 6
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "targets": [
+              {
+                "expr": "avg_over_time((sum(kube_pod_container_resource_requests{resource=\"cpu\"}) / (sum(kube_node_status_allocatable{resource=\"cpu\"}) - max(kube_node_status_allocatable{resource=\"cpu\"})))[$__range:5m])",
+                "refId": "A",
+                "instant": true,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "unit": "percentunit",
+                "decimals": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.85
+                    },
+                    {
+                      "color": "red",
+                      "value": 1.0
+                    }
+                  ]
+                },
+                "color": {
+                  "mode": "thresholds"
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background",
+              "textMode": "auto",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              }
+            }
+          },
+          {
+            "id": 200,
+            "type": "text",
+            "title": "Legend",
+            "gridPos": {
+              "x": 0,
+              "y": 6,
+              "w": 24,
+              "h": 16
+            },
+            "options": {
+              "mode": "markdown",
+              "content": "### How to read this dashboard\n\nAll numbers are **averaged over the time range** selected in the Grafana time picker (top right). Per-namespace numbers also respect the **Namespaces** filter at the top of the dashboard.\n\n**Compliance % = actual usage \u00f7 requested capacity.**\n\n#### Namespace categories (top filter)\n\n- **Application** \u2014 DOME-built workloads (analytics, billing, marketplace, zammad, etc.)\n- **Infrastructure** \u2014 ops/monitoring/GitOps add-ons (argocd, cert-manager, falco, kube-prometheus-stack, loki, velero, ingress-nginx, sealed-secrets, promtail, external-dns)\n- **System** \u2014 Kubernetes core (kube-system, kube-public, kube-node-lease, default) \u2014 *opt-in*\n\n\n#### Per-namespace cell colors\n\n| Cell | \ud83d\udfe2 Green | \ud83d\udfe1 Yellow | \ud83d\udd34 Red |\n|---|---|---|---|\n| **CPU %** | 30\u201380% (healthy) | <30% wasteful, or 80\u2013120% tight | >120% throttled |\n| **Memory %** | 30\u201380% (healthy) | <30% wasteful, or 80\u2013100% tight | >100% **OOM risk** |\n| **Storage %** | <50% | 50\u201380% monitor, 80\u201395% plan expansion | >95% **disk full** |\n| **Pods w/o requests** | 0 | \u2013 | \u22651 (invisible to scheduler) |\n\nA dash (\u2014) means there is no data for that cell \u2014 usually because no pod in the namespace has set a request for that resource.\n\n#### Status column rollup\n\n- **\u2713 OK** \u2014 nothing flagged\n- **\u26a0 Watch** \u2014 at least one cell is yellow\n- **\u26a1 Act** \u2014 at least one cell is red \u2014 investigate\n\n#### Top stats (cluster-wide; ignores the namespace filter)\n\nCluster **requested** = sum of resource requests across all pods \u00f7 total cluster allocatable. **Used** = actual consumption. The gap between them is reclaim opportunity. **N-1 CPU pressure** > 1.0 means a single node failure causes pending pods (the Apr 2026 incident pattern)."
+            }
+          },
+          {
+            "id": 100,
+            "type": "table",
+            "title": "Namespace Compliance",
+            "description": "Per-namespace usage vs requests, averaged over the selected time range.",
+            "gridPos": {
+              "x": 0,
+              "y": 22,
+              "w": 24,
+              "h": 16
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "targets": [
+              {
+                "refId": "CPU",
+                "expr": "avg_over_time((sum by (namespace) (rate(container_cpu_usage_seconds_total{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}[5m])) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"cpu\",namespace=~\"${category:pipe}\"}))[$__range:5m])",
+                "instant": true,
+                "format": "table",
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              },
+              {
+                "refId": "MEM",
+                "expr": "avg_over_time((sum by (namespace) (container_memory_working_set_bytes{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"memory\",namespace=~\"${category:pipe}\"}))[$__range:5m])",
+                "instant": true,
+                "format": "table",
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              },
+              {
+                "refId": "STORAGE",
+                "expr": "avg_over_time((sum by (namespace) (kubelet_volume_stats_used_bytes{namespace=~\"${category:pipe}\"}) / sum by (namespace) (kubelet_volume_stats_capacity_bytes{namespace=~\"${category:pipe}\"}))[$__range:5m])",
+                "instant": true,
+                "format": "table",
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              },
+              {
+                "refId": "NOREQ",
+                "expr": "sum by (namespace) (count by (namespace, pod, container) (kube_pod_container_info{pod!=\"\",namespace=~\"${category:pipe}\"}) unless on (namespace, pod, container) kube_pod_container_resource_requests{resource=\"cpu\",namespace=~\"${category:pipe}\"})",
+                "instant": true,
+                "format": "table",
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              },
+              {
+                "refId": "STATUS",
+                "expr": "max by (namespace) (((sum by (namespace) (count by (namespace, pod, container) (kube_pod_container_info{pod!=\"\",namespace=~\"${category:pipe}\"}) unless on (namespace, pod, container) kube_pod_container_resource_requests{resource=\"cpu\",namespace=~\"${category:pipe}\"}) > 0) > bool 0) * 3 or (((avg_over_time((sum by (namespace) (container_memory_working_set_bytes{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"memory\",namespace=~\"${category:pipe}\"}))[$__range:5m])) > 1.0) > bool 0) * 3 or (((avg_over_time((sum by (namespace) (rate(container_cpu_usage_seconds_total{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}[5m])) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"cpu\",namespace=~\"${category:pipe}\"}))[$__range:5m])) > 1.2) > bool 0) * 3 or (((avg_over_time((sum by (namespace) (kubelet_volume_stats_used_bytes{namespace=~\"${category:pipe}\"}) / sum by (namespace) (kubelet_volume_stats_capacity_bytes{namespace=~\"${category:pipe}\"}))[$__range:5m])) > 0.9) > bool 0) * 3 or (((avg_over_time((sum by (namespace) (container_memory_working_set_bytes{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"memory\",namespace=~\"${category:pipe}\"}))[$__range:5m])) > 0.8) > bool 0) * 2 or (((avg_over_time((sum by (namespace) (container_memory_working_set_bytes{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"memory\",namespace=~\"${category:pipe}\"}))[$__range:5m])) < 0.3) > bool 0) * 2 or (((avg_over_time((sum by (namespace) (rate(container_cpu_usage_seconds_total{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}[5m])) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"cpu\",namespace=~\"${category:pipe}\"}))[$__range:5m])) > 0.8) > bool 0) * 2 or (((avg_over_time((sum by (namespace) (rate(container_cpu_usage_seconds_total{container!=\"POD\",container!=\"\",namespace=~\"${category:pipe}\"}[5m])) / sum by (namespace) (kube_pod_container_resource_requests{resource=\"cpu\",namespace=~\"${category:pipe}\"}))[$__range:5m])) < 0.3) > bool 0) * 2 or (((avg_over_time((sum by (namespace) (kubelet_volume_stats_used_bytes{namespace=~\"${category:pipe}\"}) / sum by (namespace) (kubelet_volume_stats_capacity_bytes{namespace=~\"${category:pipe}\"}))[$__range:5m])) > 0.7) > bool 0) * 2 or sum by (namespace) (kube_pod_container_info{pod!=\"\",namespace=~\"${category:pipe}\"}) * 0 + 1)",
+                "instant": true,
+                "format": "table",
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                }
+              }
+            ],
+            "transformations": [
+              {
+                "id": "filterFieldsByName",
+                "options": {
+                  "include": {
+                    "pattern": "namespace|Value.*"
+                  }
+                }
+              },
+              {
+                "id": "joinByField",
+                "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+                }
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "renameByName": {
+                    "namespace": "Namespace",
+                    "Value #CPU": "CPU %",
+                    "Value #MEM": "Memory %",
+                    "Value #STORAGE": "Storage %",
+                    "Value #NOREQ": "Pods w/o requests",
+                    "Value #STATUS": "Status"
+                  },
+                  "indexByName": {
+                    "namespace": 0,
+                    "Value #CPU": 1,
+                    "Value #MEM": 2,
+                    "Value #STORAGE": 3,
+                    "Value #NOREQ": 4,
+                    "Value #STATUS": 5
+                  }
+                }
+              }
+            ],
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "color-background",
+                    "mode": "basic"
+                  },
+                  "filterable": true
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU %"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "percentunit"
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 1
+                    },
+                    {
+                      "id": "noValue",
+                      "value": "\u2014"
+                    },
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "type": "special",
+                          "options": {
+                            "match": "null",
+                            "result": {
+                              "text": "\u2014",
+                              "color": "rgba(80, 80, 80, 0.35)",
+                              "index": 0
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "yellow",
+                            "value": null
+                          },
+                          {
+                            "color": "green",
+                            "value": 0.3
+                          },
+                          {
+                            "color": "yellow",
+                            "value": 0.8
+                          },
+                          {
+                            "color": "red",
+                            "value": 1.2
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Memory %"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "percentunit"
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 1
+                    },
+                    {
+                      "id": "noValue",
+                      "value": "\u2014"
+                    },
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "type": "special",
+                          "options": {
+                            "match": "null",
+                            "result": {
+                              "text": "\u2014",
+                              "color": "rgba(80, 80, 80, 0.35)",
+                              "index": 0
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "yellow",
+                            "value": null
+                          },
+                          {
+                            "color": "green",
+                            "value": 0.3
+                          },
+                          {
+                            "color": "yellow",
+                            "value": 0.8
+                          },
+                          {
+                            "color": "red",
+                            "value": 1.0
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Storage %"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "percentunit"
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 1
+                    },
+                    {
+                      "id": "noValue",
+                      "value": "\u2014"
+                    },
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "type": "special",
+                          "options": {
+                            "match": "null",
+                            "result": {
+                              "text": "\u2014",
+                              "color": "rgba(80, 80, 80, 0.35)",
+                              "index": 0
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "green",
+                            "value": null
+                          },
+                          {
+                            "color": "yellow",
+                            "value": 0.5
+                          },
+                          {
+                            "color": "orange",
+                            "value": 0.8
+                          },
+                          {
+                            "color": "red",
+                            "value": 0.95
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Pods w/o requests"
+                  },
+                  "properties": [
+                    {
+                      "id": "decimals",
+                      "value": 0
+                    },
+                    {
+                      "id": "noValue",
+                      "value": "0"
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "green",
+                            "value": null
+                          },
+                          {
+                            "color": "red",
+                            "value": 1
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Status"
+                  },
+                  "properties": [
+                    {
+                      "id": "decimals",
+                      "value": 0
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "green",
+                            "value": null
+                          },
+                          {
+                            "color": "yellow",
+                            "value": 2
+                          },
+                          {
+                            "color": "red",
+                            "value": 3
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "type": "value",
+                          "options": {
+                            "1": {
+                              "text": "\u2713 OK",
+                              "color": "green",
+                              "index": 0
+                            },
+                            "2": {
+                              "text": "\u26a0 Watch",
+                              "color": "yellow",
+                              "index": 1
+                            },
+                            "3": {
+                              "text": "\u26a1 Act",
+                              "color": "red",
+                              "index": 2
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "options": {
+              "showHeader": true,
+              "footer": {
+                "show": false
+              },
+              "sortBy": [
+                {
+                  "displayName": "Status",
+                  "desc": true
+                }
+              ]
+            }
+          }
+        ],
+        "links": []
+      }

--- a/ionos_prd/grafana-dashboards/weekly-capacity-management.yaml
+++ b/ionos_prd/grafana-dashboards/weekly-capacity-management.yaml
@@ -1,0 +1,773 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: weekly-capacity-management
+data:
+  weekly-capacity-management.json: |-
+      {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": {
+                "type": "grafana",
+                "uid": "-- Grafana --"
+              },
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "description": "This dashboard is dedicated to closely monitor of the resource consumption for PRD ",
+        "editable": true,
+        "fiscalYearStartMonth": 0,
+        "graphTooltip": 0,
+        "links": [],
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": 3,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=~\"$namespace\"}) by (namespace)",
+                "instant": false,
+                "legendFormat": "{{namespace}} - Requested Capacity",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kubelet_volume_stats_used_bytes{namespace=~\"$namespace\"}) by (namespace)",
+                "hide": false,
+                "instant": false,
+                "legendFormat": "{{namespace}} - Used Data",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Weekly Storage Usage vs Capacity",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 9
+            },
+            "id": 2,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"$namespace\"}) by (namespace)",
+                "instant": false,
+                "legendFormat": "{{namespace}} - Requested",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(container_memory_working_set_bytes{container!=\"\", namespace=~\"$namespace\"}) by (namespace)",
+                "hide": false,
+                "instant": false,
+                "legendFormat": "{{namespace}} - Used",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Weekly Memory Usage vs Requests",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 17
+            },
+            "id": 1,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"$namespace\"}) by (namespace)",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "{{namespace}} - Requested",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"\", namespace=~\"$namespace\"}[5m])) by (namespace)",
+                "hide": false,
+                "instant": false,
+                "legendFormat": "{{namespace}} - Used",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Weekly CPU Usage vs Requests",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "fillOpacity": 80,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineWidth": 1,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 23,
+              "w": 20,
+              "x": 2,
+              "y": 26
+            },
+            "id": 4,
+            "options": {
+              "barRadius": 0,
+              "barWidth": 0.6,
+              "fullHighlight": false,
+              "groupWidth": 0.7,
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "orientation": "horizontal",
+              "showValue": "auto",
+              "stacking": "none",
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
+              },
+              "xField": "namespace",
+              "xTickLabelRotation": 0,
+              "xTickLabelSpacing": 0
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=~\"$namespace\"}) by (namespace)",
+                "instant": true,
+                "legendFormat": "Val. Req.",
+                "range": false,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kubelet_volume_stats_used_bytes{namespace=~\"$namespace\"}) by (namespace)",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "Val Using",
+                "range": false,
+                "refId": "B"
+              }
+            ],
+            "title": "Storage Requested vs Used per Namespace",
+            "transformations": [
+              {
+                "id": "labelsToFields",
+                "options": {}
+              },
+              {
+                "id": "joinByField",
+                "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+                }
+              }
+            ],
+            "type": "barchart"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "fillOpacity": 80,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineWidth": 1,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 25,
+              "w": 20,
+              "x": 2,
+              "y": 49
+            },
+            "id": 5,
+            "options": {
+              "barRadius": 0,
+              "barWidth": 0.6,
+              "fullHighlight": false,
+              "groupWidth": 0.7,
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "orientation": "horizontal",
+              "showValue": "auto",
+              "stacking": "none",
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
+              },
+              "xField": "namespace",
+              "xTickLabelRotation": 0,
+              "xTickLabelSpacing": 0
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"$namespace\"}) by (namespace)",
+                "instant": true,
+                "legendFormat": "Val. Req.",
+                "range": false,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(container_memory_working_set_bytes{container!=\"\", namespace=~\"$namespace\"}) by (namespace)",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "Val Using",
+                "range": false,
+                "refId": "B"
+              }
+            ],
+            "title": "Memory Requested vs Used per Namespace",
+            "transformations": [
+              {
+                "id": "labelsToFields",
+                "options": {}
+              },
+              {
+                "id": "joinByField",
+                "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+                }
+              }
+            ],
+            "type": "barchart"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "fillOpacity": 80,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineWidth": 1,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 27,
+              "w": 20,
+              "x": 2,
+              "y": 74
+            },
+            "id": 6,
+            "options": {
+              "barRadius": 0,
+              "barWidth": 0.6,
+              "fullHighlight": false,
+              "groupWidth": 0.7,
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "orientation": "horizontal",
+              "showValue": "auto",
+              "stacking": "none",
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
+              },
+              "xField": "namespace",
+              "xTickLabelRotation": 0,
+              "xTickLabelSpacing": 0
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"$namespace\"}) by (namespace)",
+                "format": "time_series",
+                "instant": true,
+                "legendFormat": "Val. Req.",
+                "range": false,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"\", namespace=~\"$namespace\"}[5m])) by (namespace)",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "Val Using",
+                "range": false,
+                "refId": "B"
+              }
+            ],
+            "title": "CPU Requested vs Used per Namespace",
+            "transformations": [
+              {
+                "id": "labelsToFields",
+                "options": {}
+              },
+              {
+                "id": "joinByField",
+                "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+                }
+              }
+            ],
+            "type": "barchart"
+          }
+        ],
+        "schemaVersion": 39,
+        "tags": [],
+        "templating": {
+          "list": [
+            {
+              "current": {
+                "selected": true,
+                "text": [
+                  "All"
+                ],
+                "value": [
+                  "$__all"
+                ]
+              },
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "definition": "label_values(namespace)",
+              "hide": 0,
+              "includeAll": true,
+              "multi": true,
+              "name": "namespace",
+              "options": [],
+              "query": {
+                "qryType": 1,
+                "query": "label_values(namespace)",
+                "refId": "PrometheusVariableQueryEditor-VariableQuery"
+              },
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "type": "query"
+            }
+          ]
+        },
+        "time": {
+          "from": "now-7d",
+          "to": "now"
+        },
+        "timeRangeUpdatedDuringEditOrView": false,
+        "timepicker": {},
+        "timezone": "browser",
+        "title": "Weekly Capacity Management -DOME-PRD Environment",
+        "weekStart": ""
+      }


### PR DESCRIPTION
## Summary

Adds two auto-loaded Grafana dashboards for dome-prd capacity tracking. Both are picked up automatically by the existing `kube-prometheus-stack` ArgoCD app, which already watches `ionos_prd/grafana-dashboards/` as one of its sources — no Helm values change, no new ArgoCD app needed.

### Dashboard 1 — Weekly Capacity Management

The original imported dashboard.

### Dashboard 2 — Namespace Compliance Overview *(added in this update)*

Rolls up CPU / memory / storage compliance per namespace (usage ÷ requests, averaged over the selected time range) plus cluster-level capacity context. Includes:

- **Six cluster stat panels** at the top: CPU requested/used, Memory requested/used, Storage used, N-1 node-loss CPU pressure — all averaged over `$__range`.
- **Markdown legend** explaining the column thresholds and the Status rollup.
- **Namespace Compliance table** with per-cell color thresholds and a per-row Status rollup column (`✓ OK` / `⚠ Watch` / `⚡ Act`).
- **Namespace categories** multi-select variable, defaulting to *Application + Infrastructure*. *System* (kube-system, kube-public, kube-node-lease, default) is opt-in.

This is the dashboard that surfaced the infrastructure-namespace red signals tracked in issues #2671–#2679.

## How dashboards auto-load (the existing pattern)

`kube-prometheus-stack` already includes `ionos_prd/grafana-dashboards/` as a multi-source path. Each file in that directory is a `ConfigMap` with label `grafana_dashboard: "1"`. Grafana's sidecar watches the cluster for these labeled ConfigMaps and imports them without restarting Grafana.

This follows the existing pattern used by `ticketing-analytics.yaml`.

## Verification

Both ConfigMaps:

```sh
kubectl --context dome-prod apply --dry-run=server \
  -f ionos_prd/grafana-dashboards/weekly-capacity-management.yaml \
  -f ionos_prd/grafana-dashboards/namespace-compliance-overview.yaml \
  -n kube-prometheus-stack
# configmap/weekly-capacity-management unchanged (server dry run)
# configmap/namespace-compliance-overview unchanged (server dry run)
```

Both dashboards were applied directly to the cluster (kubectl apply) ahead of this PR being merged so we could iterate on them visually. The PR now contains the final committed-to-git version. When this PR merges, ArgoCD adopts ownership of both ConfigMaps via server-side apply (same data, no churn, no disruption).

## Related

- #2671 – #2679 — the 9 infrastructure-namespace resource-request issues surfaced by the Namespace Compliance dashboard

## Test plan

- [ ] After merge, ArgoCD `kube-prometheus-stack` reaches Synced + Healthy
- [ ] Both ConfigMaps exist in `kube-prometheus-stack` namespace
- [ ] Both dashboards visible at https://grafana.dome-marketplace-prd.org
- [ ] All panels render data (no "Datasource not found" errors)