### PR TITLE
DEV2 - Remove the hardcoded URLs from BAE landing

### DIFF
--- a/ionos_dev2/marketplace/bae/values.yaml
+++ b/ionos_dev2/marketplace/bae/values.yaml
@@ -203,7 +203,7 @@ business-api-ecosystem:
     statefulset:
       image:
         repository: fiware/biz-ecosystem-logic-proxy
-        tag: "11.19.6"
+        tag: "11.19.7"
         pullPolicy: Always
 
     ingress: 


### PR DESCRIPTION
This PR removes the on boarding hardcoded URLs from the BAE landing page in DEV2