### PR TITLE
Infrastructure: PRD — argocd resource requests

### DIFF
--- a/ionos_prd/argocd/values.yaml
+++ b/ionos_prd/argocd/values.yaml
@@ -25,6 +25,13 @@ redis-ha:
 
 controller:
   replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -41,6 +48,13 @@ controller:
 
 server:
   replicas: 1
+  resources:
+    requests:
+      cpu: 20m
+      memory: 96Mi
+    limits:
+      cpu: 200m
+      memory: 192Mi
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -66,6 +80,13 @@ server:
 
 repoServer:
   replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1500m
+      memory: 3Gi
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -82,19 +103,49 @@ repoServer:
 
 applicationSet:
   replicas: 1
+  resources:
+    requests:
+      cpu: 20m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
   metrics:
     enabled: true
     serviceMonitor:
       enabled: true
 
 dex:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
   metrics:
     enabled: true
     serviceMonitor:
       enabled: true
 
 redis:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
   metrics:
     enabled: true
     serviceMonitor:
       enabled: true
+
+notifications:
+  resources:
+    requests:
+      cpu: 20m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi


### PR DESCRIPTION
Closes #2673

## Summary

Adds CPU/memory `resources` (requests + limits) to all 7 Argo CD components in the **production** (`ionos_prd`) overlay. Previously these workloads ran with no resource constraints. Change is confined to `ionos_prd/argocd/values.yaml` — `resources:` blocks were merged into the existing component keys; the pre-existing `affinity:` (PR #2498) and `metrics:` blocks were preserved untouched. A new top-level `notifications:` block was added (none existed before).

This avoids the failure mode of PR #2492, which placed values at a path the chart never read: every value here was confirmed to reach the rendered manifests via `helm template` (see below).

## Sizing

| Component | CPU req | Mem req | CPU lim | Mem lim |
|---|---|---|---|---|
| controller | 200m | 512Mi | 500m | 1Gi |
| repoServer | 200m | 256Mi | **1500m** | **3Gi** |
| server | 20m | 96Mi | 200m | 192Mi |
| applicationSet | 20m | 64Mi | 100m | 128Mi |
| notifications | 20m | 64Mi | 100m | 128Mi |
| dex | 10m | 64Mi | 100m | 128Mi |
| redis | 10m | 32Mi | 100m | 64Mi |

### Note on the deliberately-large repo-server limit
`repoServer` keeps a high memory limit (**3Gi**) and high CPU limit (**1500m**) on purpose: it spikes to ~1 core / ~2.8Gi during chart rendering. Undersizing it would re-trigger the April-2026 CrashLoop, so these headroom values are intentional.

## Verification (`helm template`)

Rendered locally against chart `argo-cd` `7.1.1` from `https://argoproj.github.io/argo-helm` with this file as values. All 7 workloads render their `resources` block with the exact values above:

- ✅ application-controller (StatefulSet)
- ✅ repo-server (Deployment)
- ✅ server (Deployment)
- ✅ applicationset-controller (Deployment)
- ✅ notifications-controller (Deployment) — confirmed the chart reads `notifications.resources`
- ✅ dex-server (Deployment)
- ✅ redis (Deployment)

Existing `affinity` (podAntiAffinity) blocks on controller / server / repo-server confirmed still present in the rendered output.

DOME is in maintenance mode — this is a small, surgical values-only change. No human approval is implied by this PR.
