### PR TITLE
Infrastructure: PRD — loki-distributed resource requests

### DIFF
--- a/ionos_prd/loki-distributed/values.yaml
+++ b/ionos_prd/loki-distributed/values.yaml
@@ -3,6 +3,13 @@ global:
 
 compactor:
   enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 
 ingester:
   persistence:
@@ -10,7 +17,49 @@ ingester:
     claims:
       - name: data
         size: 200Gi
+  resources:
+    requests:
+      cpu: 20m
+      memory: 512Mi
+    limits:
+      cpu: 200m
+      memory: 768Mi
+
+distributor:
+  resources:
+    requests:
+      cpu: 20m
+      memory: 192Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
 querier:
   persistence:
     enabled: true
     size: 200Gi
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+queryFrontend:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+gateway:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi


### PR DESCRIPTION
Closes #2674

## Summary

Adds CPU/memory resource `requests` and `limits` to all six `loki-distributed`
components in production (`ionos_prd/loki-distributed/values.yaml`). Previously
these components ran with no resource constraints. The `resources:` blocks are
merged into the existing per-component keys, preserving all current config
(ingester/querier persistence claims, `compactor.enabled`).

## Sizing

| Component | requests (cpu / mem) | limits (cpu / mem) |
|---|---|---|
| ingester | 20m / 512Mi | 200m / 768Mi |
| distributor | 20m / 192Mi | 200m / 256Mi |
| querier | 10m / 64Mi | 100m / 128Mi |
| queryFrontend | 10m / 32Mi | 100m / 64Mi |
| compactor | 10m / 64Mi | 100m / 128Mi |
| gateway | 10m / 32Mi | 100m / 64Mi |

## Verification (helm template)

Rendered locally against the exact chart ArgoCD uses
(`grafana/loki-distributed` version `0.79.0`) with this values file, and
confirmed every component's container carries the expected `resources` block —
guarding against the silent-failure mode of PR #2492 (values placed at a path
the chart never reads). The chart's query-frontend deployment reads
`.Values.queryFrontend.resources` (camelCase), which is the key used here.

```
helm template loki grafana/loki-distributed --version 0.79.0 \
  -f ionos_prd/loki-distributed/values.yaml
```

| Component | Rendered workload | resources present |
|---|---|---|
| ingester | StatefulSet `loki-loki-distributed-ingester` | ✅ |
| distributor | Deployment `loki-loki-distributed-distributor` | ✅ |
| querier | StatefulSet `loki-loki-distributed-querier` | ✅ |
| query-frontend | Deployment `loki-loki-distributed-query-frontend` | ✅ |
| compactor | StatefulSet `loki-loki-distributed-compactor` | ✅ |
| gateway | Deployment `loki-loki-distributed-gateway` | ✅ |

All 6 components rendered their resources block with values matching the table above.
