### PR TITLE
Infrastructure: sealed-secrets resource requests (ionos_common — all envs)

### DIFF
--- a/ionos_common/sealed-secrets/values.yaml
+++ b/ionos_common/sealed-secrets/values.yaml
@@ -8,3 +8,10 @@ sealed-secrets:
     enabled: false
   containerSecurityContext:
     enabled: false
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi


### PR DESCRIPTION
Closes #2678

## Summary
Adds CPU/memory resource requests and limits to the sealed-secrets controller, which currently runs with **no resource requests** at all. Defining requests/limits makes the pod schedulable predictably and protects the node from a runaway controller.

## Change
Single file: `ionos_common/sealed-secrets/values.yaml` — added a `resources:` block under the existing top-level `sealed-secrets:` (subchart) key:

```yaml
  resources:
    requests:
      cpu: 10m
      memory: 32Mi
    limits:
      cpu: 100m
      memory: 64Mi
```

## ⚠️ Scope: ALL environments
This file lives in **`ionos_common/`**, which is **shared across every environment (dev, dev2, sbx, prd)** — it is **not** PRD-only. This change applies the controller resources everywhere. That is intended and desirable: the sealed-secrets controller is identical and tiny in every environment.

## Sizing rationale
The controller's observed peak usage is ~23Mi memory / ~1m CPU. Requests (10m / 32Mi) sit comfortably above idle with headroom; limits (100m / 64Mi) leave ample burst room while staying small.

## Verification (helm template)
Rendered the wrapper chart locally with `helm template` (subchart `sealed-secrets` 2.12.0 from the bitnami-labs chart). The bitnami-labs GitHub Pages helm repo index now returns 404, so the chart `.tgz` was pulled from the GitHub release asset and vendored into `charts/` for the render only (not committed).

The resources block renders into the controller **Deployment** container spec:

```
# Source: sealed-secrets/charts/sealed-secrets/templates/deployment.yaml
kind: Deployment
...
          resources:
            limits:
              cpu: 100m
              memory: 64Mi
            requests:
              cpu: 10m
              memory: 32Mi
```

The subchart template gates on `{{- if .Values.resources }}` and emits `resources: {{- toYaml .Values.resources | nindent 12 }}`, so the value at `sealed-secrets: → resources:` reaches the rendered manifest. This addresses the failure mode of PR #2492 (values placed at a path the chart never read).