### PR TITLE
Infrastructure: PRD — kube-prometheus-stack resource requests (Prometheus memory + Grafana sidecars)

### DIFF
--- a/ionos_prd/kube-prometheus-stack/values.yaml
+++ b/ionos_prd/kube-prometheus-stack/values.yaml
@@ -36,8 +36,23 @@ grafana:
         contains(groups[*], '@DOME-Marketplace/dome-grafana-prod-ro') && 'Viewer'
   resources:
     requests:
-      cpu: 150m
-      memory: 350Mi
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 300m
+      memory: 384Mi
+  sidecar:
+    # Shared resources for ALL Grafana sidecar containers (dashboard + datasource,
+    # incl. their init container). The grafana subchart (v8.0.2) reads only
+    # `sidecar.resources`; there is no per-type sidecar.dashboards/datasources.resources
+    # path. Setting this lifts the Grafana pod out of BestEffort QoS.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 96Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
   extraSecretMounts:
     - name: kube-prometheus-stack-sso
       secretName: kube-prometheus-stack-sso
@@ -79,7 +94,10 @@ prometheusOperator:
   resources:
     requests:
       cpu: 20m
-      memory: 50Mi
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
   admissionWebhooks:
     deployment:
       resources:
@@ -106,7 +124,10 @@ prometheus:
     resources:
       requests:
         cpu: 200m
-        memory: 1000Mi
+        memory: 1500Mi
+      limits:
+        cpu: 1000m
+        memory: 2Gi
     storageSpec:
       volumeClaimTemplate:
         spec:
@@ -117,13 +138,19 @@ prometheus:
 prometheus-node-exporter:
   resources:
     requests:
-      cpu: 5m
-      memory: 20Mi
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 kube-state-metrics:
   resources:
     requests:
-      cpu: 3m
-      memory: 50Mi
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
 alertmanager:
   config:
     route:
@@ -149,6 +176,9 @@ alertmanager:
     resources:
       requests:
         cpu: 20m
-        memory: 50Mi
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
   #   secrets:
   #     - kube-prometheus-stack-discord-infrastructure-webhook-secret


### PR DESCRIPTION
Closes #2672

## Problem
Two issues in the PRD `kube-prometheus-stack` resource config:

1. **Prometheus memory overcommit / OOM risk.** Prometheus runs at ~1290Mi avg / ~1587Mi peak but only requested **1000Mi** (117% overcommit) and had **no memory limit**. Under pressure it risks OOM and node eviction.
2. **Grafana sidecars in BestEffort QoS.** The two Grafana sidecar containers (`grafana-sc-dashboard`, `grafana-sc-datasources`) had **no resource requests**, which dragged the entire Grafana pod into **BestEffort** QoS (first to be evicted under node memory pressure).

Several other components (operator, kube-state-metrics, node-exporter, alertmanager) had requests but **no limits**.

## Change
Right-size requests and add limits across all components (values from #2672). Only `resources:` blocks were added/updated — all existing config (ingress, SSO, datasources, alerting, storage, admission webhooks) is untouched.

| Component | requests (cpu/mem) | limits (cpu/mem) |
|---|---|---|
| Prometheus | 200m / 1500Mi | 1000m / 2Gi |
| Alertmanager | 20m / 64Mi | 100m / 128Mi |
| Grafana (main) | 100m / 256Mi | 300m / 384Mi |
| Grafana sidecars (both) | 10m / 96Mi | 100m / 128Mi |
| Prometheus Operator | 20m / 64Mi | 100m / 128Mi |
| kube-state-metrics | 10m / 32Mi | 100m / 64Mi |
| node-exporter | 10m / 64Mi | 100m / 128Mi |

### Note on the Grafana sidecar path
The grafana subchart (v8.0.2, bundled in kube-prometheus-stack 60.2.0) applies **a single shared `grafana.sidecar.resources`** block to *all* sidecar containers (dashboard + datasource + their init container). There is **no** per-type `sidecar.dashboards.resources` / `sidecar.datasources.resources` path — setting those would silently no-op. This PR uses the path the chart actually reads, verified below.

## Verification (`helm template`, chart 60.2.0)
Rendered the manifests with this values file and confirmed each component's resources land in the output. Prometheus & Alertmanager are operator-managed, so their resources land in the `Prometheus`/`Alertmanager` CR `spec.resources` (the operator builds the StatefulSets from those at runtime).

- [x] **Prometheus** CR `spec.resources` → 200m/1500Mi, limits 1000m/2Gi
- [x] **Alertmanager** CR `spec.resources` → 20m/64Mi, limits 100m/128Mi
- [x] **Grafana** Deployment main container → 100m/256Mi, limits 300m/384Mi
- [x] **Grafana** `grafana-sc-dashboard` sidecar → 10m/96Mi, limits 100m/128Mi
- [x] **Grafana** `grafana-sc-datasources` sidecar → 10m/96Mi, limits 100m/128Mi
- [x] **Prometheus Operator** Deployment → 20m/64Mi, limits 100m/128Mi
- [x] **kube-state-metrics** Deployment → 10m/32Mi, limits 100m/64Mi
- [x] **node-exporter** DaemonSet → 10m/64Mi, limits 100m/128Mi

All 8 components confirmed rendering their resources.