### PR TITLE
Infrastructure: PRD — cert-manager resource requests

### DIFF
--- a/ionos_prd/cert-manager/values.yaml
+++ b/ionos_prd/cert-manager/values.yaml
@@ -1,2 +1,25 @@
 cert-manager:
   installCRDs: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  cainjector:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 96Mi
+      limits:
+        cpu: 100m
+        memory: 192Mi
+  webhook:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi


### PR DESCRIPTION
Closes #2677

## Summary
Adds CPU/memory **requests and limits** to all three cert-manager components in production (`ionos_prd/cert-manager/values.yaml`). The containers previously ran with **no resource requests**, leaving them unschedulable-safe but vulnerable to eviction/noisy-neighbor pressure. This is a small, surgical outage-prevention change (DOME is in maintenance mode).

Values are nested under the `cert-manager:` subchart key (jetstack chart `v1.12.4`, declared as a dependency in `Chart.yaml`).

## Sizing
Requests sized just above observed peaks; limits give comfortable headroom.

| Component | requests | limits | observed peak |
|---|---|---|---|
| controller (`resources:`) | cpu 10m / mem 64Mi | cpu 100m / mem 128Mi | 53Mi |
| cainjector (`cainjector.resources:`) | cpu 10m / mem 96Mi | cpu 100m / mem 192Mi | 68Mi |
| webhook (`webhook.resources:`) | cpu 10m / mem 32Mi | cpu 100m / mem 64Mi | 13Mi |

## Verification
Rendered locally with the actual jetstack subchart:

```
helm dependency build
helm template cert-manager . -f values.yaml
```

Confirmed that **all three Deployments** — `cert-manager` (controller), `cert-manager-cainjector`, and `cert-manager-webhook` — each render a populated `resources:` block with the values above (no empty `resources: {}` remain). This guards against the failure mode of PR #2492, where values were placed at a path the chart never reads.

No build artifacts (`charts/`, `Chart.lock`) are committed, consistent with the rest of `ionos_prd/`.