### PR TITLE
Infrastructure: PRD — promtail resource requests

### DIFF
--- a/ionos_prd/promtail/values.yaml
+++ b/ionos_prd/promtail/values.yaml
@@ -2,3 +2,11 @@ config:
   clients:
     - url: >-
         http://loki-distributed-gateway.loki-distributed.svc.cluster.local/loki/api/v1/push
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  limits:
+    cpu: 200m
+    memory: 384Mi


### PR DESCRIPTION
Closes #2676

## Summary
Add CPU/memory resource requests and limits to the **promtail** DaemonSet in `ionos_prd`. promtail currently has no requests, so its pods run as **BestEffort** QoS on every node — first to be evicted under node memory pressure. This sets sensible requests/limits to give it Burstable QoS and protect log shipping.

## Change
`ionos_prd/promtail/values.yaml` — added the chart's top-level `resources:` key (this file is passed directly as the grafana `promtail` chart's values; resources belong at the top level, not nested):

```yaml
resources:
  requests:
    cpu: 50m
    memory: 256Mi
  limits:
    cpu: 200m
    memory: 384Mi
```

## Sizing rationale
30-day observed peak ≈ **192Mi / 48m** per pod. Requests set just above peak (256Mi / 50m); limits give ~2x memory headroom (384Mi) and burst CPU (200m).

## Verification (helm template)
Rendered the actual ArgoCD chart locally and confirmed the values reach the DaemonSet container — the path PR #2492 got wrong:

```
helm template promtail grafana/promtail --version 6.16.0 -f ionos_prd/promtail/values.yaml
```

Rendered DaemonSet container `resources:` block:
```yaml
          resources:
            limits:
              cpu: 200m
              memory: 384Mi
            requests:
              cpu: 50m
              memory: 256Mi
```
✅ Resources confirmed present in the rendered promtail DaemonSet.

## Notes
- Maintenance-mode: surgical change, single key added, all other values preserved.
- Not merged — review before applying.
