### PR TITLE
Infrastructure: PRD — ingress-nginx resource requests

### DIFF
--- a/ionos_prd/ingress/values.yaml
+++ b/ionos_prd/ingress/values.yaml
@@ -12,3 +12,10 @@ ingress-nginx:
       http2-max-field-size: "32k"
       http2-max-header-size: "32k"
       proxy-body-size: "10m"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 384Mi


### PR DESCRIPTION
Closes #2671

One-line: add CPU/memory resource requests and limits to the production `ingress-nginx` controller DaemonSet, which previously ran with only a ~90Mi memory request and no limit.

### Before / after

| | request cpu | request mem | limit cpu | limit mem |
|---|---|---|---|---|
| Before | (chart default) | ~90Mi | none | none |
| After | `100m` | `256Mi` | `500m` | `384Mi` |

Sizing: over the last 30 days controller memory peaked at 207Mi (avg 180Mi) — about 215% of the previous 90Mi request. The 256Mi request sits comfortably above the observed peak; the 384Mi limit caps runaway usage.

### Verification

Verified locally with `helm template` — the controller DaemonSet renders the resources block (value path `ingress-nginx.controller.resources` reaches the rendered container). This guards against the silent no-op of #2492, where values sat at a path the chart never read.

Scope: single-file change to `ionos_prd/ingress/values.yaml`; no other resources touched.
