### PR TITLE
Infrastructure: PRD — falco init container & falcosidekick resource requests

### DIFF
--- a/ionos_prd/falco/values.yaml
+++ b/ionos_prd/falco/values.yaml
@@ -1,7 +1,24 @@
 driver:
   kind: ebpf
+falcoctl:
+  artifact:
+    follow:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
 falcosidekick:
   enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 48Mi
+    limits:
+      cpu: 100m
+      memory: 96Mi
   serviceMonitor:
     enabled: true
   prometheusRules:


### PR DESCRIPTION
Closes #2675

## Summary
Adds CPU/memory resource requests and limits to two falco components in production (`ionos_prd/falco/values.yaml`) that previously had none, so the scheduler can place them correctly and they are protected from noisy-neighbour eviction.

## Changes
- **`falcoctl-artifact-follow`** (the long-running falcoctl sidecar/init container in the falco DaemonSet) — chart path `falcoctl.artifact.follow.resources`:
  - requests: `cpu 10m`, `memory 32Mi`
  - limits:   `cpu 100m`, `memory 64Mi`
- **`falcosidekick`** Deployment — chart path `falcosidekick.resources`:
  - requests: `cpu 10m`, `memory 48Mi`
  - limits:   `cpu 100m`, `memory 96Mi`

Merged into the existing `falcosidekick:` key (preserving `enabled`, `serviceMonitor`, `prometheusRules`, `config`); `falcoctl:` added as a new key.

## Intentionally unchanged
The **main `falco` DaemonSet container** is already correctly sized via chart defaults (requests `100m`/`512Mi`, limits `1000m`/`1024Mi`) and is **not** touched by this PR.

## Verification (helm template)
Rendered locally against the exact chart ArgoCD uses — `falcosecurity/falco` version `4.21.3` — with this values file:

```
helm template falco falcosecurity/falco --version 4.21.3 -f ionos_prd/falco/values.yaml
```

Confirmed in the rendered manifests:
- ✅ `falcoctl-artifact-follow` container in the falco DaemonSet shows `requests cpu 10m / memory 32Mi`, `limits cpu 100m / memory 64Mi`.
- ✅ `falcosidekick` Deployment container shows `requests cpu 10m / memory 48Mi`, `limits cpu 100m / memory 96Mi`.
- ✅ Main `falco` container still renders chart defaults (`100m`/`512Mi` req, `1000m`/`1024Mi` limit) — unchanged.

This addresses the failure mode of PR #2492, where values were placed at a path the chart never reads; here the resources are confirmed to land in the rendered output.

Note: not merging — for human review.
