### PR TITLE
SBX - Increase the max size for files in the BAE ingress

### DIFF
--- a/ionos_sbx/marketplace/bae/values.yaml
+++ b/ionos_sbx/marketplace/bae/values.yaml
@@ -217,6 +217,7 @@ business-api-ecosystem:
       className: nginx
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-sbx-issuer
+        nginx.ingress.kubernetes.io/proxy-body-size: "20m"
       tls: 
        -  hosts: 
             - dome-marketplace-sbx.org


### PR DESCRIPTION
This PR update the BAE config in SBX to increase the max size to 20Mb in the ingress