### PR TITLE
SBX: point certification issuer to LCL for v3 integration test

### DIFF
--- a/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
+++ b/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
@@ -32,4 +32,5 @@ data:
   JWT_OAUTH_CLIENT_ID: did:key:zDnaep7iGodkmSEUD8uAsp4dhqcaxxrFQ3zgyANHD2brt7CgB
   JWT_OAUTH_REDIRECT_URI: https://dome-certification.dome-marketplace-sbx.org/auth/login
   JWT_OAUTH_AUD: https://verifier.dome-marketplace-sbx.org
-  JWT_ISSUER_URL: https://issuer.dome-marketplace-sbx.org
+  JWT_OAUTH_ISSUER: https://issuer.dome-marketplace-lcl.org
+  JWT_ISSUER_URL: https://issuer.dome-marketplace-lcl.org


### PR DESCRIPTION
Temporary: JWT_OAUTH_ISSUER (used by the backend) and JWT_ISSUER_URL both now target the LCL issuer (issuer.dome-marketplace-lcl.org) to validate the Digital Identity v3 integration before it lands on SBX. Revert both to https://issuer.dome-marketplace-sbx.org once v3 is on SBX.