### PR TITLE
SBX: point certification verifier to LCL (v3 integration test)

### DIFF
--- a/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
+++ b/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
@@ -31,6 +31,6 @@ data:
   JWT_PUBLIC_KEY_Y: 2ewVHc6-KbG3xNkogzA5okub-A87ecgi3o2k2Tg7kaM
   JWT_OAUTH_CLIENT_ID: did:key:zDnaep7iGodkmSEUD8uAsp4dhqcaxxrFQ3zgyANHD2brt7CgB
   JWT_OAUTH_REDIRECT_URI: https://dome-certification.dome-marketplace-sbx.org/auth/login
-  JWT_OAUTH_AUD: https://verifier.dome-marketplace-sbx.org
+  JWT_OAUTH_AUD: https://verifier.dome-marketplace-lcl.org
   JWT_OAUTH_ISSUER: https://issuer.dome-marketplace-lcl.org
   JWT_ISSUER_URL: https://issuer.dome-marketplace-lcl.org

--- a/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.17
+          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.18
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
Verifier switches on both sides together so login keeps working:
- backend: JWT_OAUTH_AUD -> https://verifier.dome-marketplace-lcl.org
- frontend: image -> sbx-1.1.18 (built with VERIFIER_URL and ISSUER_API pointing to the LCL endpoints; these are compiled into the Angular bundle).

Temporary for the Digital Identity v3 integration test; revert to the *-sbx.org verifier once v3 is available on SBX.