### PR TITLE
SBX: fix verifier LCL URL to include /verifier path (v3)

### DIFF
--- a/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
+++ b/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
@@ -31,6 +31,6 @@ data:
   JWT_PUBLIC_KEY_Y: 2ewVHc6-KbG3xNkogzA5okub-A87ecgi3o2k2Tg7kaM
   JWT_OAUTH_CLIENT_ID: did:key:zDnaep7iGodkmSEUD8uAsp4dhqcaxxrFQ3zgyANHD2brt7CgB
   JWT_OAUTH_REDIRECT_URI: https://dome-certification.dome-marketplace-sbx.org/auth/login
-  JWT_OAUTH_AUD: https://verifier.dome-marketplace-lcl.org
+  JWT_OAUTH_AUD: https://verifier.dome-marketplace-lcl.org/verifier
   JWT_OAUTH_ISSUER: https://issuer.dome-marketplace-lcl.org
   JWT_ISSUER_URL: https://issuer.dome-marketplace-lcl.org

--- a/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.18
+          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.19
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
The v3 verifier serves its OIDC issuer/endpoints under /verifier, not at the host root, which broke login (discovery issuer mismatch on the frontend, wrong JWKS URL on the backend).

- backend: JWT_OAUTH_AUD -> https://verifier.dome-marketplace-lcl.org/verifier
- frontend: image -> sbx-1.1.19 (VERIFIER_URL now .../verifier)

