### PR TITLE
PRD: upgrade certification to 1.4.2 / frontend prd-1.1.6

### DIFF
--- a/ionos_prd/dome-certification/backend/certification-backend-config.yaml
+++ b/ionos_prd/dome-certification/backend/certification-backend-config.yaml
@@ -20,6 +20,7 @@ data:
   # LOGGING_LEVEL_ROOT: INFO
   SPRING_MAIL_USERNAME: certification@dome-marketplace.eu
   SPRING_MAIL_ADDRESS: certification@dome-marketplace.eu
+  EMAIL_ADDRESS: certification@dome-marketplace.eu
   SPRING_MAIL_HOST: smtp.ionos.de
   SPRING_MAIL_PORT: "587"
   SPRING_MAIL_SMPT_AUTH: "true"
@@ -32,4 +33,5 @@ data:
   JWT_OAUTH_CLIENT_ID: did:key:zDnaemuFzGnbeSpxGUKmXMo354Nhvivfao3UjrNqLyJKX34gw
   JWT_OAUTH_REDIRECT_URI: https://dome-certification.dome-marketplace.eu/auth/login
   JWT_OAUTH_AUD: https://verifier.dome-marketplace.eu
+  JWT_OAUTH_ISSUER: https://issuer.dome-marketplace.eu
   JWT_ISSUER_URL: https://issuer.dome-marketplace.eu

--- a/ionos_prd/dome-certification/backend/certification-backend.yaml
+++ b/ionos_prd/dome-certification/backend/certification-backend.yaml
@@ -6,6 +6,8 @@ metadata:
     app: certification-backend
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: certification-backend
@@ -16,9 +18,9 @@ spec:
     spec:
       containers:
         - name: certification-backend
-          image: noeliaguedek/dome-compliance-backend:prd-1.1.8
+          image: bfeitaisuw/dome-compliance-backend:1.4.2
           env:
-            - name: POSTGRES_PASSWORD
+            - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: dekra-postgres-secret

--- a/ionos_prd/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_prd/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: noeliaguedek/dome-compliance-frontend:prd-1.1.5
+          image: bfeitaisuw/dome-compliance-frontend:prd-1.1.6
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
Brings production in line with dev2:
- backend image -> bfeitaisuw/dome-compliance-backend:1.4.2 (didkey optional on wallet login, tolerant credential parsing, wallet-only auth)
- DB password env: POSTGRES_PASSWORD -> SPRING_DATASOURCE_PASSWORD (1.4.2 reads SPRING_DATASOURCE_PASSWORD; the old var was ignored by Spring)
- add strategy: Recreate (RWO upload volume; avoids Multi-Attach on redeploy)
- configmap: add JWT_OAUTH_ISSUER (used by the code for issuance) and EMAIL_ADDRESS
- frontend image -> bfeitaisuw/dome-compliance-frontend:prd-1.1.6 (rebuilt with CLIENT_ID = did:key:zDnaemuFz... to match the backend signing key; fixes the current prod login mismatch 'OAuth parameters do not match JWT claims')