### PR TITLE
SBX - ticketing system, limits the number of memory allocation arenas…

### DIFF
--- a/ionos_sbx/zammad/values.yaml
+++ b/ionos_sbx/zammad/values.yaml
@@ -112,3 +112,7 @@ zammad:
       limits:
         cpu: "250m"
         memory: "256Mi"
+
+  extraEnv:
+    - name: MALLOC_ARENA_MAX
+      value: "2"


### PR DESCRIPTION
… used by glibc