### PR TITLE
PRD: fix certification frontend image -> prd-1.1.7

### DIFF
--- a/ionos_prd/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_prd/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: bfeitaisuw/dome-compliance-frontend:prd-1.1.6
+          image: bfeitaisuw/dome-compliance-frontend:prd-1.1.7
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
prd-1.1.6 was built from the stale 'develop' branch and shipped an outdated frontend (missing the QA updates and compliance features).

prd-1.1.7 is built from the right branch, with CLIENT_ID = did:key:zDnaemuFz... (matching the backend signing key).