### PR TITLE
SBX: point certification verifier to v3 SBX URL (.../verifier)

### DIFF
--- a/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
+++ b/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
@@ -31,6 +31,6 @@ data:
   JWT_PUBLIC_KEY_Y: 2ewVHc6-KbG3xNkogzA5okub-A87ecgi3o2k2Tg7kaM
   JWT_OAUTH_CLIENT_ID: did:key:zDnaep7iGodkmSEUD8uAsp4dhqcaxxrFQ3zgyANHD2brt7CgB
   JWT_OAUTH_REDIRECT_URI: https://dome-certification.dome-marketplace-sbx.org/auth/login
-  JWT_OAUTH_AUD: https://verifier.dome-marketplace-lcl.org/verifier
+  JWT_OAUTH_AUD: https://verifier.dome-marketplace-sbx.org/verifier
   JWT_OAUTH_ISSUER: https://issuer.dome-marketplace-lcl.org
   JWT_ISSUER_URL: https://issuer.dome-marketplace-lcl.org

--- a/ionos_sbx/dome-certification/backend/certification-backend.yaml
+++ b/ionos_sbx/dome-certification/backend/certification-backend.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: certification-backend
-          image: bfeitaisuw/dome-compliance-backend:1.4.2
+          image: bfeitaisuw/dome-compliance-backend:1.4.3
           env:
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:

--- a/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.19
+          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.20
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
DOME exposed the v3 verifier at the SBX URL; switch from the temporary LCL target back to SBX, keeping the /verifier path that v3 requires.
- backend: JWT_OAUTH_AUD -> https://verifier.dome-marketplace-sbx.org/verifier
- frontend: image -> sbx-1.1.20 (built with VERIFIER_URL = .../verifier)

Note: JWT_OAUTH_ISSUER is left on LCL for now (Roger's request only covers the verifier); to be revisited once the issuer's SBX/v3 endpoint is confirmed.