### PR TITLE
PRD: fix certification client_id to match backend signing key (zDnaeRQm)

### DIFF
--- a/ionos_prd/dome-certification/backend/certification-backend-config.yaml
+++ b/ionos_prd/dome-certification/backend/certification-backend-config.yaml
@@ -28,9 +28,9 @@ data:
   SPRING_MAIL_SMPT_START_TLS_REQUIRED: "true"
   SPRING_MAIL_SMPT_SSL_TRUST: smtp.ionos.de
   SPRING_MAIL_SMPT_DEBUG: "false"
-  JWT_PUBLIC_KEY_X: PwNDhtQdvbbHGt6uU9GCaHrcdn16R80PaQ8tDe0O9yg
-  JWT_PUBLIC_KEY_Y: 8rTQYRipfQ6RCAMJE3e-6qVeSfsRHtq3qSWSpBUMjPM
-  JWT_OAUTH_CLIENT_ID: did:key:zDnaemuFzGnbeSpxGUKmXMo354Nhvivfao3UjrNqLyJKX34gw
+  JWT_PUBLIC_KEY_X: Do06qo0bvqad3ho6K-rcZL3tbsSNX7mSkoxL2j_bOHI
+  JWT_PUBLIC_KEY_Y: l6JmyUFy43kYKnVYO1mmu4hoqVlCNzNUSq0CMA-D-0Q
+  JWT_OAUTH_CLIENT_ID: did:key:zDnaeRQmf6te2Gnoo1xQetePbyJfh2kLaHnYNr5z5PbSMWXL5
   JWT_OAUTH_REDIRECT_URI: https://dome-certification.dome-marketplace.eu/auth/login
   JWT_OAUTH_AUD: https://verifier.dome-marketplace.eu
   JWT_OAUTH_ISSUER: https://issuer.dome-marketplace.eu

--- a/ionos_prd/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_prd/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: bfeitaisuw/dome-compliance-frontend:prd-1.1.7
+          image: bfeitaisuw/dome-compliance-frontend:prd-1.1.8
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
The prod backend's private key corresponds to
did:key:zDnaeRQmf6te2Gnoo1xQetePbyJfh2kLaHnYNr5z5PbSMWXL5 (verified cryptographically). Aligns configmap client_id + public coords + frontend image (prd-1.1.8, built with CLIENT_ID=zDnaeRQm) to that key.

NOTE: requires the IAM team to register zDnaeRQm in the prod trusted_services_list, otherwise login still 403s at the verifier.