### PR TITLE
SBX: bump certification frontend to sbx-1.1.21 (label-tier logic fixes)

### DIFF
--- a/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.20
+          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.21
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
Fixes the tier computation (fail-closed professional guard, PT/ST cert handling, CS-20 visibility) and moves the document-classification UX to the product-details page. Pairs with the DB normalization (per-criterion label_level PR -> P) already applied to the SBX database.