### PR TITLE
SBX: bump certification frontend to sbx-1.1.22

### DIFF
--- a/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
+++ b/ionos_sbx/dome-certification/frontend/certification-frontend.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certification-frontend
-          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.21
+          image: bfeitaisuw/dome-compliance-frontend:sbx-1.1.22
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION


Gates Validate/Confirm until every uploaded file is classified, and adds a 'discard (not valid)' classification for bad certs in a bundle. Frontend-only.