### PR TITLE
SBX: issuer issuance route fix (backend 1.4.4) + point issuer back to…

### DIFF
--- a/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
+++ b/ionos_sbx/dome-certification/backend/certification-backend-config.yaml
@@ -32,5 +32,5 @@ data:
   JWT_OAUTH_CLIENT_ID: did:key:zDnaep7iGodkmSEUD8uAsp4dhqcaxxrFQ3zgyANHD2brt7CgB
   JWT_OAUTH_REDIRECT_URI: https://dome-certification.dome-marketplace-sbx.org/auth/login
   JWT_OAUTH_AUD: https://verifier.dome-marketplace-sbx.org/verifier
-  JWT_OAUTH_ISSUER: https://issuer.dome-marketplace-lcl.org
-  JWT_ISSUER_URL: https://issuer.dome-marketplace-lcl.org
+  JWT_OAUTH_ISSUER: https://issuer.dome-marketplace-sbx.org
+  JWT_ISSUER_URL: https://issuer.dome-marketplace-sbx.org

--- a/ionos_sbx/dome-certification/backend/certification-backend.yaml
+++ b/ionos_sbx/dome-certification/backend/certification-backend.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: certification-backend
-          image: bfeitaisuw/dome-compliance-backend:1.4.3
+          image: bfeitaisuw/dome-compliance-backend:1.4.4
           env:
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:


### PR DESCRIPTION
… SBX

- backend image -> bfeitaisuw/dome-compliance-backend:1.4.4 (issuance route now /vci/v1/issuances; old /issuer-api/... route is CloudFront-blocked for POST)
- JWT_OAUTH_ISSUER / JWT_ISSUER_URL -> https://issuer.dome-marketplace-sbx.org (base domain, no trailing slash; back to SBX from the earlier LCL test target)